### PR TITLE
Fix/issue 20

### DIFF
--- a/libwallet/src/internal/scan.rs
+++ b/libwallet/src/internal/scan.rs
@@ -14,8 +14,6 @@
 //! Functions to restore a wallet's outputs from just the master seed
 
 use crate::api_impl::owner_updater::StatusMessage;
-use crate::epic_core::consensus::{valid_header_version, WEEK_HEIGHT};
-use crate::epic_core::core::HeaderVersion;
 use crate::epic_core::global;
 use crate::epic_core::libtx::proof;
 use crate::epic_keychain::{Identifier, Keychain, SwitchCommitmentType};
@@ -76,7 +74,6 @@ where
 
 	let legacy_builder = proof::LegacyProofBuilder::new(keychain);
 	let builder = proof::ProofBuilder::new(keychain);
-	let legacy_version = HeaderVersion(6);
 
 	for output in outputs.iter() {
 		let (commit, proof, is_coinbase, height, mmr_index) = output;
@@ -365,7 +362,7 @@ where
 		wallet_lock!(wallet_inst, w);
 		updater::retrieve_outputs(&mut **w, keychain_mask, true, false, None, None)?
 	};
-
+	
 	let mut missing_outs = vec![];
 	let mut accidental_spend_outs = vec![];
 	let mut locked_outs = vec![];

--- a/libwallet/src/internal/scan.rs
+++ b/libwallet/src/internal/scan.rs
@@ -83,18 +83,14 @@ where
 		// attempt to unwind message from the RP and get a value
 		// will fail if it's not ours
 		let info = {
-			// Before HF+2wk, try legacy rewind first
-			let info_legacy = if valid_header_version(*height, legacy_version) {
+			// Try new rewind first
+			let info_new = proof::rewind(keychain.secp(), &builder, *commit, None, *proof)?;
+
+			// If new didn't work, try legacy rewind
+			if info_new.is_none() {
 				proof::rewind(keychain.secp(), &legacy_builder, *commit, None, *proof)?
 			} else {
-				None
-			};
-
-			// If legacy didn't work, try new rewind
-			if info_legacy.is_none() {
-				proof::rewind(keychain.secp(), &builder, *commit, None, *proof)?
-			} else {
-				info_legacy
+				info_new
 			}
 		};
 

--- a/libwallet/src/internal/updater.rs
+++ b/libwallet/src/internal/updater.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::epic_core::consensus::{cumulative_reward_foundation, header_version, reward};
-use crate::epic_core::core::block::HeaderVersion;
 use crate::epic_core::core::{Output, TxKernel};
 use crate::epic_core::global;
 use crate::epic_core::libtx::proof::{LegacyProofBuilder, ProofBuilder};
@@ -55,7 +54,7 @@ where
 		.iter()
 		.filter(|out| show_spent || out.status != OutputStatus::Spent)
 		.collect::<Vec<_>>();
-
+		
 	if show_full_history {
 		outputs.append(
 			&mut wallet


### PR DESCRIPTION
I changed the function that retrieves the chain information associated with my wallet, more specifically this is:

Inside the scan function in the file _/epic-wallet/libwallet/src/internal/scan.rs_, we have the function that gets the chain information, called _collect_chain_outputs_.

Within this function we have the specific part that searches for transactions belonging to my wallet, this function is called _identify_utxo_outputs_.

Inside it we have the part that rewinds the transaction, that's where I changed it. Before he checked the version of the header, to do the rewind with the builder in the correct version.

I removed this header version check and thus making it rewind with the two builders, legacy and new, and return what it found the transition.