### PR TITLE
Refactor error handling on SQLite implementation

### DIFF
--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -398,7 +398,6 @@ where
 	) -> Result<Box<dyn WalletOutputBatch<K> + 'a>, Error> {
 		Ok(Box::new(Batch {
 			_store: self,
-			//db: RefCell::new(Some(self.db.batch())?),
 			db: RefCell::new(match self.db.batch() {
 				Ok(w_batch) => Some(w_batch),
 				Err(er) => {
@@ -412,7 +411,6 @@ where
 	fn batch_no_mask<'a>(&'a mut self) -> Result<Box<dyn WalletOutputBatch<K> + 'a>, Error> {
 		Ok(Box::new(Batch {
 			_store: self,
-			//db: RefCell::new(Some(self.db.batch()?)),
 			db: RefCell::new(match self.db.batch() {
 				Ok(w_batch) => Some(w_batch),
 				Err(er) => {
@@ -425,7 +423,6 @@ where
 
 	fn current_child_index<'a>(&mut self, parent_key_id: &Identifier) -> Result<u32, Error> {
 		let index = {
-			//let batch = self.db.batch()?;
 			let batch = match self.db.batch() {
 				Ok(w_batch) => w_batch,
 				Err(er) => {

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -429,7 +429,10 @@ where
 			let batch = match self.db.batch() {
 				Ok(w_batch) => w_batch,
 				Err(er) => {
-					panic!("Error getting batch itself in child_index function! Error {}", er)
+					panic!(
+						"Error getting batch itself in child_index function! Error {}",
+						er
+					)
 				}
 			};
 			let deriv_key = to_key(DERIV_PREFIX, &mut parent_key_id.to_bytes().to_vec());
@@ -453,7 +456,10 @@ where
 			let batch = match self.db.batch() {
 				Ok(w_batch) => w_batch,
 				Err(er) => {
-					panic!("Error getting batch itself in next_child function! Error {}", er)
+					panic!(
+						"Error getting batch itself in next_child function! Error {}",
+						er
+					)
 				}
 			};
 			let deriv_key = to_key(DERIV_PREFIX, &mut self.parent_key_id.to_bytes().to_vec());
@@ -482,7 +488,10 @@ where
 		let batch = match self.db.batch() {
 			Ok(w_batch) => w_batch,
 			Err(er) => {
-				panic!("Error getting batch itself in last_confirmed function! Error {}", er)
+				panic!(
+					"Error getting batch itself in last_confirmed function! Error {}",
+					er
+				)
 			}
 		};
 		let height_key = to_key(
@@ -506,7 +515,10 @@ where
 		let batch = match self.db.batch() {
 			Ok(w_batch) => w_batch,
 			Err(er) => {
-				panic!("Error getting batch itself in last_scanned function! Error {}", er)
+				panic!(
+					"Error getting batch itself in last_scanned function! Error {}",
+					er
+				)
 			}
 		};
 		let scanned_block_key = to_key(
@@ -535,7 +547,10 @@ where
 		let batch = match self.db.batch() {
 			Ok(w_batch) => w_batch,
 			Err(er) => {
-				panic!("Error getting batch itself in init_status function! Error {}", er)
+				panic!(
+					"Error getting batch itself in init_status function! Error {}",
+					er
+				)
 			}
 		};
 		let init_status_key = to_key(

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -402,8 +402,7 @@ where
 			db: RefCell::new(match self.db.batch() {
 				Ok(w_batch) => Some(w_batch),
 				Err(er) => {
-					error!("Error on lmdb.rs implementation! Error {}", er);
-					panic!("Error on lmdb.rs implementation! Error {}", er)
+					panic!("Error on creating batch! Error {}", er)
 				}
 			}),
 			keychain: Some(self.keychain(keychain_mask)?),
@@ -417,8 +416,7 @@ where
 			db: RefCell::new(match self.db.batch() {
 				Ok(w_batch) => Some(w_batch),
 				Err(er) => {
-					error!("Error on lmdb.rs implementation! Error {}", er);
-					panic!("Error on lmdb.rs implementation! Error {}", er)
+					panic!("Error on creating batch without mask! Error {}", er)
 				}
 			}),
 			keychain: None,
@@ -431,16 +429,14 @@ where
 			let batch = match self.db.batch() {
 				Ok(w_batch) => w_batch,
 				Err(er) => {
-					error!("Error on lmdb.rs implementation! Error {}", er);
-					panic!("Error on lmdb.rs implementation! Error {}", er)
+					panic!("Error getting batch itself in child_index function! Error {}", er)
 				}
 			};
 			let deriv_key = to_key(DERIV_PREFIX, &mut parent_key_id.to_bytes().to_vec());
 			let batch_ser = match batch.get_ser(&deriv_key) {
 				Ok(ser) => ser,
 				Err(er) => {
-					error!("Error on lmdb.rs implementation! Error {}", er);
-					panic!("Error on lmdb.rs implementation! Error {}", er)
+					panic!("Error getting the serialized batch with deriv_key in child_index function! Error {}", er)
 				}
 			};
 			match batch_ser {
@@ -457,16 +453,14 @@ where
 			let batch = match self.db.batch() {
 				Ok(w_batch) => w_batch,
 				Err(er) => {
-					error!("Error on lmdb.rs implementation! Error {}", er);
-					panic!("Error on lmdb.rs implementation! Error {}", er)
+					panic!("Error getting batch itself in next_child function! Error {}", er)
 				}
 			};
 			let deriv_key = to_key(DERIV_PREFIX, &mut self.parent_key_id.to_bytes().to_vec());
 			let batch_ser = match batch.get_ser(&deriv_key) {
 				Ok(ser) => ser,
 				Err(er) => {
-					error!("Error on lmdb.rs implementation! Error {}", er);
-					panic!("Error on lmdb.rs implementation! Error {}", er)
+					panic!("Error getting the serialized batch with deriv_key in next_child function! Error {}", er)
 				}
 			};
 			match batch_ser {
@@ -488,8 +482,7 @@ where
 		let batch = match self.db.batch() {
 			Ok(w_batch) => w_batch,
 			Err(er) => {
-				error!("Error on lmdb.rs implementation! Error {}", er);
-				panic!("Error on lmdb.rs implementation! Error {}", er)
+				panic!("Error getting batch itself in last_confirmed function! Error {}", er)
 			}
 		};
 		let height_key = to_key(
@@ -499,8 +492,7 @@ where
 		let batch_ser = match batch.get_ser(&height_key) {
 			Ok(ser) => ser,
 			Err(er) => {
-				error!("Error on lmdb.rs implementation! Error {}", er);
-				panic!("Error on lmdb.rs implementation! Error {}", er)
+				panic!("Error getting the serialized batch with height_key in last_confirmed function! Error {}", er)
 			}
 		};
 		let last_confirmed_height = match batch_ser {
@@ -514,8 +506,7 @@ where
 		let batch = match self.db.batch() {
 			Ok(w_batch) => w_batch,
 			Err(er) => {
-				error!("Error on lmdb.rs implementation! Error {}", er);
-				panic!("Error on lmdb.rs implementation! Error {}", er)
+				panic!("Error getting batch itself in last_scanned function! Error {}", er)
 			}
 		};
 		let scanned_block_key = to_key(
@@ -525,8 +516,7 @@ where
 		let batch_ser = match batch.get_ser(&scanned_block_key) {
 			Ok(ser) => ser,
 			Err(er) => {
-				error!("Error on lmdb.rs implementation! Error {}", er);
-				panic!("Error on lmdb.rs implementation! Error {}", er)
+				panic!("Error getting the serialized batch with scanned_key in last_scanned function! Error {}", er)
 			}
 		};
 		let last_scanned_block = match batch_ser {
@@ -545,8 +535,7 @@ where
 		let batch = match self.db.batch() {
 			Ok(w_batch) => w_batch,
 			Err(er) => {
-				error!("Error on lmdb.rs implementation! Error {}", er);
-				panic!("Error on lmdb.rs implementation! Error {}", er)
+				panic!("Error getting batch itself in init_status function! Error {}", er)
 			}
 		};
 		let init_status_key = to_key(
@@ -556,8 +545,7 @@ where
 		let batch_ser = match batch.get_ser(&init_status_key) {
 			Ok(ser) => ser,
 			Err(er) => {
-				error!("Error on lmdb.rs implementation! Error {}", er);
-				panic!("Error on lmdb.rs implementation! Error {}", er)
+				panic!("Error getting the serialized batch with init_key in init_status function! Error {}", er)
 			}
 		};
 		let status = match batch_ser {

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -404,7 +404,7 @@ where
 				Err(er) => {
 					error!("Error on lmdb.rs implementation! Error {}", er);
 					panic!("Error on lmdb.rs implementation! Error {}", er)
-				},
+				}
 			}),
 			keychain: Some(self.keychain(keychain_mask)?),
 		}))
@@ -414,15 +414,13 @@ where
 		Ok(Box::new(Batch {
 			_store: self,
 			//db: RefCell::new(Some(self.db.batch()?)),
-			db: RefCell::new(
-				match self.db.batch() {
-					Ok(w_batch) => Some(w_batch),
-					Err(er) => {
-						error!("Error on lmdb.rs implementation! Error {}", er);
-						panic!("Error on lmdb.rs implementation! Error {}", er)
-					},
+			db: RefCell::new(match self.db.batch() {
+				Ok(w_batch) => Some(w_batch),
+				Err(er) => {
+					error!("Error on lmdb.rs implementation! Error {}", er);
+					panic!("Error on lmdb.rs implementation! Error {}", er)
 				}
-			),
+			}),
 			keychain: None,
 		}))
 	}
@@ -435,7 +433,7 @@ where
 				Err(er) => {
 					error!("Error on lmdb.rs implementation! Error {}", er);
 					panic!("Error on lmdb.rs implementation! Error {}", er)
-				},
+				}
 			};
 			let deriv_key = to_key(DERIV_PREFIX, &mut parent_key_id.to_bytes().to_vec());
 			let batch_ser = match batch.get_ser(&deriv_key) {
@@ -443,7 +441,7 @@ where
 				Err(er) => {
 					error!("Error on lmdb.rs implementation! Error {}", er);
 					panic!("Error on lmdb.rs implementation! Error {}", er)
-				},
+				}
 			};
 			match batch_ser {
 				Some(idx) => idx,
@@ -461,7 +459,7 @@ where
 				Err(er) => {
 					error!("Error on lmdb.rs implementation! Error {}", er);
 					panic!("Error on lmdb.rs implementation! Error {}", er)
-				},
+				}
 			};
 			let deriv_key = to_key(DERIV_PREFIX, &mut self.parent_key_id.to_bytes().to_vec());
 			let batch_ser = match batch.get_ser(&deriv_key) {
@@ -469,7 +467,7 @@ where
 				Err(er) => {
 					error!("Error on lmdb.rs implementation! Error {}", er);
 					panic!("Error on lmdb.rs implementation! Error {}", er)
-				},
+				}
 			};
 			match batch_ser {
 				Some(idx) => idx,
@@ -492,7 +490,7 @@ where
 			Err(er) => {
 				error!("Error on lmdb.rs implementation! Error {}", er);
 				panic!("Error on lmdb.rs implementation! Error {}", er)
-			},
+			}
 		};
 		let height_key = to_key(
 			CONFIRMED_HEIGHT_PREFIX,
@@ -503,7 +501,7 @@ where
 			Err(er) => {
 				error!("Error on lmdb.rs implementation! Error {}", er);
 				panic!("Error on lmdb.rs implementation! Error {}", er)
-			},
+			}
 		};
 		let last_confirmed_height = match batch_ser {
 			Some(h) => h,
@@ -518,7 +516,7 @@ where
 			Err(er) => {
 				error!("Error on lmdb.rs implementation! Error {}", er);
 				panic!("Error on lmdb.rs implementation! Error {}", er)
-			},
+			}
 		};
 		let scanned_block_key = to_key(
 			LAST_SCANNED_BLOCK,
@@ -529,7 +527,7 @@ where
 			Err(er) => {
 				error!("Error on lmdb.rs implementation! Error {}", er);
 				panic!("Error on lmdb.rs implementation! Error {}", er)
-			},
+			}
 		};
 		let last_scanned_block = match batch_ser {
 			Some(b) => b,
@@ -549,7 +547,7 @@ where
 			Err(er) => {
 				error!("Error on lmdb.rs implementation! Error {}", er);
 				panic!("Error on lmdb.rs implementation! Error {}", er)
-			},
+			}
 		};
 		let init_status_key = to_key(
 			WALLET_INIT_STATUS,
@@ -560,7 +558,7 @@ where
 			Err(er) => {
 				error!("Error on lmdb.rs implementation! Error {}", er);
 				panic!("Error on lmdb.rs implementation! Error {}", er)
-			},
+			}
 		};
 		let status = match batch_ser {
 			Some(s) => s,

--- a/impls/src/error.rs
+++ b/impls/src/error.rs
@@ -20,6 +20,7 @@ use crate::util::secp;
 use failure::{Backtrace, Context, Fail};
 use std::env;
 use std::fmt::{self, Display};
+use std::error;
 
 /// Error definition
 #[derive(Debug)]
@@ -100,6 +101,32 @@ impl Fail for Error {
 		self.inner.backtrace()
 	}
 }
+
+
+// impl From<dyn error::Error + 'static> for Error {
+// 	fn from(error: libtx::Error) -> Error {
+// 		Error {
+// 			inner: Context::new(ErrorKind::LibTX(error.kind())),
+// 		}
+// 	}
+// }
+
+// impl From <dyn error::Error + 'static> for Error {
+// 	fn source(&self) -> Option<&(dyn Error + 'static)> {
+//         Some(&self.name)
+//     }
+// }
+	// fn from(error: libwallet::Error) -> Error {
+	// 	Error {
+	// 		inner: Context::new(ErrorKind::LibWallet(error.kind(), format!("{}", error))),
+	// 	}
+	// }
+
+// impl error::Error for Error {
+// 	fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+// 		Some(&self.inner)
+// 	}
+// }
 
 impl Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/impls/src/error.rs
+++ b/impls/src/error.rs
@@ -102,31 +102,6 @@ impl Fail for Error {
 	}
 }
 
-// impl From<dyn error::Error + 'static> for Error {
-// 	fn from(error: libtx::Error) -> Error {
-// 		Error {
-// 			inner: Context::new(ErrorKind::LibTX(error.kind())),
-// 		}
-// 	}
-// }
-
-// impl From <dyn error::Error + 'static> for Error {
-// 	fn source(&self) -> Option<&(dyn Error + 'static)> {
-//         Some(&self.name)
-//     }
-// }
-// fn from(error: libwallet::Error) -> Error {
-// 	Error {
-// 		inner: Context::new(ErrorKind::LibWallet(error.kind(), format!("{}", error))),
-// 	}
-// }
-
-// impl error::Error for Error {
-// 	fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-// 		Some(&self.inner)
-// 	}
-// }
-
 impl Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		let show_bt = match env::var("RUST_BACKTRACE") {

--- a/impls/src/error.rs
+++ b/impls/src/error.rs
@@ -19,8 +19,8 @@ use crate::libwallet;
 use crate::util::secp;
 use failure::{Backtrace, Context, Fail};
 use std::env;
-use std::fmt::{self, Display};
 use std::error;
+use std::fmt::{self, Display};
 
 /// Error definition
 #[derive(Debug)]
@@ -102,7 +102,6 @@ impl Fail for Error {
 	}
 }
 
-
 // impl From<dyn error::Error + 'static> for Error {
 // 	fn from(error: libtx::Error) -> Error {
 // 		Error {
@@ -116,11 +115,11 @@ impl Fail for Error {
 //         Some(&self.name)
 //     }
 // }
-	// fn from(error: libwallet::Error) -> Error {
-	// 	Error {
-	// 		inner: Context::new(ErrorKind::LibWallet(error.kind(), format!("{}", error))),
-	// 	}
-	// }
+// fn from(error: libwallet::Error) -> Error {
+// 	Error {
+// 		inner: Context::new(ErrorKind::LibWallet(error.kind(), format!("{}", error))),
+// 	}
+// }
 
 // impl error::Error for Error {
 // 	fn source(&self) -> Option<&(dyn error::Error + 'static)> {


### PR DESCRIPTION
# Description

With the new database implementation (LMDB to SQLite), the error is no longer being handled automatically.

So we need to change how the code interprets errors in functions `db.batch()` and `batch.get_ser()` on `/epic-wallet/impls/src/backends/lmdb.rs`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Build changes (changes the way the project builds)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor ( rewrite/restructure code, but does not change any behavior)

# How Has This Been Tested?

Tested by building the projects using cargo