### PR TITLE
Change --here and --help short values

### DIFF
--- a/src/bin/epic-wallet.yml
+++ b/src/bin/epic-wallet.yml
@@ -363,7 +363,7 @@ subcommands:
       args:
         - here:
             help: Create wallet files in the current directory instead of the default ~/.epic directory
-            short: h
+            short: H
             long: here
             takes_value: false
         - short_wordlist:


### PR DESCRIPTION
# Description

Change the current behavior for improved syntax.
- On init, the --here can be called using -H
- On init, the --help can be called using the traditional -h

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (miscellaneous changes e.g. modifying .gitignore)
- [ ] Build (Affect build components like build tool, ci pipeline, dependencies, project version)
- [ ] Docs (documentation update)

# How Has This Been Tested?

- Tested on Linux
- No major changes were done