### PR TITLE
Add queries to map_wallet_outputs and clean_old_unconfirmed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ test_output
 .idea/
 /build/
 release/
+.vscode/
+
+# From flamegraph
+flamegraph.svg
+perf.data*

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -389,6 +389,28 @@ where
 		Box::new(eligible)
 	}
 
+	fn old_unconfirmed_outputs(&self, height: u64) -> Box<dyn Iterator<Item = OutputData>> {
+		Box::new(
+			self.db
+				.old_unconfirmed_outputs(height)
+				.into_iter()
+				.filter_map(Serializable::as_output_data),
+		)
+	}
+
+	fn unspent_ouputs(
+		&self,
+		parent_key_id: &Identifier,
+		tx_entries_ids: Option<Vec<u32>>,
+	) -> Box<dyn Iterator<Item = OutputData>> {
+		Box::new(
+			self.db
+				.unspent_ouputs(parent_key_id, tx_entries_ids)
+				.into_iter()
+				.filter_map(Serializable::as_output_data),
+		)
+	}
+
 	fn get_private_context(
 		&mut self,
 		keychain_mask: Option<&SecretKey>,

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -226,6 +226,21 @@ where
 		key: Option<&Identifier>,
 	) -> Box<dyn Iterator<Item = OutputData>>;
 
+	/// Get old and unconfirmed outputs
+	/// A output is considered unconfirmed if the tx_status is unconfirmed and
+	/// the height of the txos is bigger than 0 and smaller than the height minus 50
+	/// It also needs to be a coinbase
+	fn old_unconfirmed_outputs(&self, height: u64) -> Box<dyn Iterator<Item = OutputData>>;
+
+	/// Returns unspent outputs
+	/// tx_entries_ids can be passed to select outputs
+	/// that are actually involved in an outstanding transaction
+	fn unspent_ouputs(
+		&self,
+		parent_key_id: &Identifier,
+		tx_entries_ids: Option<Vec<u32>>,
+	) -> Box<dyn Iterator<Item = OutputData>>;
+
 	/// Iterate over all stored account paths
 	fn acct_path_iter<'a>(&'a self) -> Box<dyn Iterator<Item = AcctPathMapping> + 'a>;
 


### PR DESCRIPTION
# Description

Optimize the map_wallet_outputs and clean_old_unconfirmed to use SQLite queries.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (miscellaneous changes e.g. modifying .gitignore)
- [ ] Build (Affect build components like build tool, ci pipeline, dependencies, project version)
- [ ] Docs (documentation update)

# How Has This Been Tested?

- Tested on a Linux machine

# Relevant notes

Also, add flamegraph and .vscode to gitignore