### PR TITLE
Adding QR method to transact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "checked_int_cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,7 +1112,7 @@ dependencies = [
  "hyper-timeout",
  "image",
  "log",
- "qr_code",
+ "qrcode",
  "quircs",
  "rand 0.5.6",
  "regex",
@@ -2663,10 +2669,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "qr_code"
-version = "1.1.0"
+name = "qrcode"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5520fbcd7da152a449261c5a533a1c7fad044e9e8aa9528cfec3f464786c7926"
+checksum = "16d2f1455f3630c6e5107b4f2b94e74d76dea80736de0981fd27644216cff57f"
+dependencies = [
+ "checked_int_cast",
+ "image",
+]
 
 [[package]]
 name = "quick-error"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +289,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "bytemuck"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
+
+[[package]]
 name = "byteorder"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +413,12 @@ checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "constant_time_eq"
@@ -607,6 +625,16 @@ name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "deflate"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
+dependencies = [
+ "adler32",
+ "byteorder 1.4.3",
+]
 
 [[package]]
 name = "difference"
@@ -1076,7 +1104,10 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-timeout",
+ "image",
  "log",
+ "qr_code",
+ "quircs",
  "rand 0.5.6",
  "regex",
  "ring",
@@ -1155,9 +1186,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.34",
+ "proc-macro2 1.0.50",
  "quote 1.0.10",
- "syn 1.0.82",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -1310,13 +1341,23 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "gif"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -1528,6 +1569,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+dependencies = [
+ "bytemuck",
+ "byteorder 1.4.3",
+ "color_quant",
+ "gif",
+ "jpeg-decoder",
+ "num-iter",
+ "num-rational 0.3.2",
+ "num-traits 0.2.14",
+ "png",
+ "scoped_threadpool",
+ "tiff",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "jsonrpc-core"
 version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,9 +1701,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
@@ -1850,6 +1919,15 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
@@ -2060,6 +2138,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2 1.0.50",
+ "quote 1.0.10",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2189,17 @@ checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
  "autocfg 1.0.1",
  "num-bigint 0.2.6",
+ "num-integer",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg 1.0.1",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -2370,9 +2470,9 @@ dependencies = [
  "phf_generator 0.8.0",
  "phf_shared 0.8.0",
  "proc-macro-hack",
- "proc-macro2 1.0.34",
+ "proc-macro2 1.0.50",
  "quote 1.0.10",
- "syn 1.0.82",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2398,6 +2498,18 @@ name = "pkg-config"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+
+[[package]]
+name = "png"
+version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "deflate",
+ "miniz_oxide 0.3.7",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2513,11 +2625,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.34"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
- "unicode-xid 0.2.2",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2551,10 +2663,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "qr_code"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5520fbcd7da152a449261c5a533a1c7fad044e9e8aa9528cfec3f464786c7926"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quircs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088cd18eb88277186050867dbfc7079eba83a753e4bc2b51c0feef6908679f4a"
+dependencies = [
+ "num-derive",
+ "num-traits 0.2.14",
+ "thiserror",
+]
 
 [[package]]
 name = "quote"
@@ -2580,7 +2709,7 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
- "proc-macro2 1.0.34",
+ "proc-macro2 1.0.50",
 ]
 
 [[package]]
@@ -2730,7 +2859,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -3045,6 +3174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 
 [[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
+
+[[package]]
 name = "scopeguard"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,9 +3247,9 @@ version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
 dependencies = [
- "proc-macro2 1.0.34",
+ "proc-macro2 1.0.50",
  "quote 1.0.10",
- "syn 1.0.82",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3314,13 +3449,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.82"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2 1.0.34",
+ "proc-macro2 1.0.50",
  "quote 1.0.10",
- "unicode-xid 0.2.2",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3329,9 +3464,9 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.34",
+ "proc-macro2 1.0.50",
  "quote 1.0.10",
- "syn 1.0.82",
+ "syn 1.0.107",
  "unicode-xid 0.2.2",
 ]
 
@@ -3424,9 +3559,9 @@ version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
- "proc-macro2 1.0.34",
+ "proc-macro2 1.0.50",
  "quote 1.0.10",
- "syn 1.0.82",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3447,6 +3582,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tiff"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437"
+dependencies = [
+ "jpeg-decoder",
+ "miniz_oxide 0.4.4",
+ "weezl",
 ]
 
 [[package]]
@@ -3798,6 +3944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3949,9 +4101,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "webpki"
@@ -3972,6 +4124,12 @@ dependencies = [
  "untrusted",
  "webpki",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "which"
@@ -4074,9 +4232,9 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
- "proc-macro2 1.0.34",
+ "proc-macro2 1.0.50",
  "quote 1.0.10",
- "syn 1.0.82",
+ "syn 1.0.107",
  "synstructure",
 ]
 

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -19,7 +19,7 @@ use crate::config::{TorConfig, WalletConfig, WALLET_CONFIG_FILE_NAME};
 use crate::core::{core, global};
 use crate::error::{Error, ErrorKind};
 use crate::impls::{create_sender, KeybaseAllChannels, SlateGetter as _, SlateReceiver as _};
-use crate::impls::{EmojiSlate, PathToSlate, SlatePutter};
+use crate::impls::{EmojiSlate, PathToSlate, QrToSlate, SlatePutter};
 use crate::keychain;
 use crate::libwallet::{
 	self, address, InitTxArgs, IssueInvoiceTxArgs, NodeClient, PaymentProof, WalletInst,
@@ -323,6 +323,12 @@ where
 			};
 
 			match args.method.as_str() {
+				"qr" => {
+					println!("Dest: {:?}, Slate: {slate:?}", &args.dest);
+					QrToSlate((&args.dest).into()).put_tx(&slate)?;
+					api.tx_lock_outputs(m, &slate, 0)?;
+					return Ok(());
+				}
 				"emoji" => {
 					println!("{}", EmojiSlate().encode(&slate, true));
 					api.tx_lock_outputs(m, &slate, 0)?;
@@ -396,9 +402,11 @@ where
 	let mut receive_compressed = true;
 	if method == "emoji" {
 		(slate, receive_compressed) = EmojiSlate().decode(&args.input.as_str())?;
+	} else if method == "qr" {
+		slate = QrToSlate((&args.input).into()).get_tx()?;
 	} else {
 		slate = PathToSlate((&args.input).into()).get_tx()?;
-	}
+	};
 
 	let km = match keychain_mask.as_ref() {
 		None => None,

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -324,7 +324,6 @@ where
 
 			match args.method.as_str() {
 				"qr" => {
-					println!("Dest: {:?}, Slate: {slate:?}", &args.dest);
 					QrToSlate((&args.dest).into()).put_tx(&slate)?;
 					api.tx_lock_outputs(m, &slate, 0)?;
 					return Ok(());
@@ -423,6 +422,8 @@ where
 	if method == "emoji" {
 		println!("\n\nThis is your response emoji string. Please send it back to the payer to finalize the transaction:\n\n{}", EmojiSlate().encode(&slate, receive_compressed));
 		info!("Response emoji.response generated, and can be sent back to the transaction originator.");
+	} else if method == "qr" {
+		QrToSlate((format!("response_{}", args.input)).into()).put_tx(&slate)?;
 	} else {
 		PathToSlate(format!("{}.response", args.input).into()).put_tx(&slate)?;
 		info!(
@@ -457,6 +458,8 @@ where
 	let mut slate;
 	if method == "emoji" {
 		(slate, _) = EmojiSlate().decode(&args.input.as_str())?;
+	} else if method == "qr" {
+		slate = QrToSlate((&args.input).into()).get_tx()?;
 	} else {
 		slate = PathToSlate((&args.input).into()).get_tx()?;
 	}

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -46,6 +46,9 @@ regex = "1.3"
 timer = "0.2"
 sysinfo = "0.9"
 flate2 = "1.0"
+qr_code = "1.1"
+image = "0.23.14"
+quircs = "0.10"
 
 epic_wallet_util = { path = "../util", version = "3.3.2" }
 epic_wallet_config = { path = "../config", version = "3.3.2" }

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -46,7 +46,7 @@ regex = "1.3"
 timer = "0.2"
 sysinfo = "0.9"
 flate2 = "1.0"
-qr_code = "1.1"
+qrcode = "0.12"
 image = "0.23.14"
 quircs = "0.10"
 

--- a/impls/src/adapters/compress.rs
+++ b/impls/src/adapters/compress.rs
@@ -16,8 +16,7 @@
 //! Has the main operations to handle the Emoji transaction, for now.
 //! This was built to make the transaction more efficient using less memory
 
-use std::io::{Read, Write};
-
+use std::io::{BufReader, Read, Write};
 extern crate flate2;
 use flate2::{
 	read::{DeflateDecoder, GzDecoder, ZlibDecoder},

--- a/impls/src/adapters/compress.rs
+++ b/impls/src/adapters/compress.rs
@@ -16,7 +16,7 @@
 //! Has the main operations to handle the Emoji transaction, for now.
 //! This was built to make the transaction more efficient using less memory
 
-use std::io::{BufReader, Read, Write};
+use std::io::{Read, Write};
 extern crate flate2;
 use flate2::{
 	read::{DeflateDecoder, GzDecoder, ZlibDecoder},

--- a/impls/src/adapters/mod.rs
+++ b/impls/src/adapters/mod.rs
@@ -24,7 +24,7 @@ pub use self::emoji::EmojiSlate;
 pub use self::file::PathToSlate;
 pub use self::http::{HttpSlateSender, SchemeNotHttp};
 pub use self::keybase::{KeybaseAllChannels, KeybaseChannel};
-pub use self::qr::QrToSlate;
+pub use self::qr::{QrToSlate, RESPONSE_EXTENTION};
 
 use crate::config::{TorConfig, WalletConfig};
 use crate::libwallet::{Error, ErrorKind, NodeClient, Slate, WalletInst, WalletLCProvider};
@@ -115,9 +115,13 @@ pub fn create_sender(
 			)
 			.into());
 		}
-		"file" => {
+		"file" | "qr" | "emoji" => {
 			return Err(ErrorKind::WalletComms(
-				"File based transactions must be performed asynchronously.".to_string(),
+				format!(
+					"{} based transactions must be performed asynchronously.",
+					method
+				)
+				.to_string(),
 			)
 			.into());
 		}

--- a/impls/src/adapters/mod.rs
+++ b/impls/src/adapters/mod.rs
@@ -18,11 +18,13 @@ mod emoji_map;
 mod file;
 pub mod http;
 mod keybase;
+mod qr;
 
 pub use self::emoji::EmojiSlate;
 pub use self::file::PathToSlate;
 pub use self::http::{HttpSlateSender, SchemeNotHttp};
 pub use self::keybase::{KeybaseAllChannels, KeybaseChannel};
+pub use self::qr::QrToSlate;
 
 use crate::config::{TorConfig, WalletConfig};
 use crate::libwallet::{Error, ErrorKind, NodeClient, Slate, WalletInst, WalletLCProvider};

--- a/impls/src/adapters/mod.rs
+++ b/impls/src/adapters/mod.rs
@@ -20,11 +20,12 @@ pub mod http;
 mod keybase;
 mod qr;
 
-pub use self::emoji::EmojiSlate;
+pub use self::compress::Header;
+pub use self::emoji::{EmojiSlate, EMOJI_VERSION};
 pub use self::file::PathToSlate;
 pub use self::http::{HttpSlateSender, SchemeNotHttp};
 pub use self::keybase::{KeybaseAllChannels, KeybaseChannel};
-pub use self::qr::{QrToSlate, RESPONSE_EXTENTION};
+pub use self::qr::{QrToSlate, QR_VERSION, RESPONSE_EXTENTION};
 
 use crate::config::{TorConfig, WalletConfig};
 use crate::libwallet::{Error, ErrorKind, NodeClient, Slate, WalletInst, WalletLCProvider};

--- a/impls/src/adapters/qr.rs
+++ b/impls/src/adapters/qr.rs
@@ -85,10 +85,8 @@ fn save2qr(data: &str, path_save: &str) {
 	// Adding the compressed data
 	compressed_data_header.extend(compressed_data);
 
-	// The original transaction will have a size X.
-	// So the response file will be roughly 9/5 = 1.8 the size of the original transaction,
-	// so the send file needs to be smaller than the maximum size / (9/5) = maximum * 5 / 9
-	if compressed_data_header.len() > LIMIT_QR_BIN * 5 / 9 {
+	// The limit to QR is 2335 values
+	if compressed_data_header.len() > LIMIT_QR_BIN {
 		panic!(
 			"DataTooLong to generate the QR code! Try to perform the transaction by another method. The size of Slate is: {:?}", compressed_data_header.len()
 		);

--- a/impls/src/adapters/qr.rs
+++ b/impls/src/adapters/qr.rs
@@ -1,0 +1,132 @@
+// Copyright 2019 The Epic Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//use image::{ImageBuffer, Rgb};
+use super::compress::{compress, decompress, CompressionFormat};
+/// File Output 'plugin' implementation
+use crate::libwallet::{Error, ErrorKind, Slate, SlateVersion, VersionedSlate};
+use crate::{SlateGetter, SlatePutter};
+use image::{open, Luma};
+use qr_code::QrCode;
+use quircs;
+use std::path::PathBuf;
+
+/// The default method to compress and decompress in this version of Epic
+const COMPRESS_METHOD: CompressionFormat = CompressionFormat::Gzip;
+
+#[derive(Clone)]
+pub struct QrToSlate(pub PathBuf);
+
+fn save2qr(data: &str, path_save: &str) {
+	println!("--1");
+
+	println!("Data: {:?}", data.len());
+
+	//let data_compressed = compress(data, COMPRESS_METHOD);
+	//println!("Data Compressed: {:?}", data_compressed.len());
+	// Encode some data into bits.
+	let code = QrCode::new(data).unwrap();
+	println!("--2");
+	// Render the bits into an image.
+
+	let b = code.to_vec();
+
+	//let image = code.render::<Luma<u8>>().build();
+	println!("--3");
+	// Save the image.
+	image.save(path_save).unwrap();
+	println!("--4");
+}
+
+fn read_qr_2(path_read: &PathBuf) -> String {
+	// open the image from disk
+	let img = image::open(path_read).expect("failed to open image");
+
+	// convert to gray scale
+	let img_gray = img.into_luma8();
+
+	// create a decoder
+	let mut decoder = quircs::Quirc::default();
+
+	// identify all qr codes
+	let codes = decoder.identify(
+		img_gray.width() as usize,
+		img_gray.height() as usize,
+		&img_gray,
+	);
+
+	for code in codes {
+		let code = code.expect("failed to extract qr code");
+		let decoded = code.decode().expect("failed to decode qr code");
+		println!("qrcode: {}", std::str::from_utf8(&decoded.payload).unwrap());
+	}
+
+	String::from("aa")
+}
+
+fn read_qr(path_read: &PathBuf) -> String {
+	println!("==1");
+	// Load the PNG image
+	let img = image::open(path_read).unwrap().to_rgb8();
+
+	println!("==2: {:?}", img.to_vec().len());
+	// Convert the PNG image to a 2D binary matrix representation of the QR code
+	let qr_matrix = qrcode::QrCode::new(img.to_vec()).unwrap();
+	println!("==3");
+	// Get the data encoded in the QR code
+	let string = qr_matrix.render().light_color(' ').dark_color('#').build();
+	println!("==4");
+	println!("QR code data: {}", string);
+
+	string
+}
+
+impl SlatePutter for QrToSlate {
+	fn put_tx(&self, slate: &Slate) -> Result<(), Error> {
+		println!("-1");
+		let out_slate = {
+			if slate.payment_proof.is_some() || slate.ttl_cutoff_height.is_some() {
+				warn!("Transaction contains features that require epic-wallet 3.0.0 or later");
+				warn!("Please ensure the other party is running epic-wallet v3.0.0 or later before sending");
+				VersionedSlate::into_version(slate.clone(), SlateVersion::V3)
+			} else {
+				let mut s = slate.clone();
+				s.version_info.version = 2;
+				s.version_info.orig_version = 2;
+				VersionedSlate::into_version(s, SlateVersion::V2)
+			}
+		};
+		println!("-2");
+		let slate_json = serde_json::to_string(&out_slate).map_err(|_| ErrorKind::SlateSer)?;
+		println!("-3");
+		let slate_bytes = slate_json.as_bytes();
+		println!("-4");
+		let path_save = self.0.to_str().unwrap(); //"Test_QR.png";
+		println!("-5, path: {:?}", path_save);
+		save2qr(&slate_json, path_save);
+		println!("-6");
+		Ok(())
+	}
+}
+
+impl SlateGetter for QrToSlate {
+	fn get_tx(&self) -> Result<Slate, Error> {
+		println!("=1");
+		let path = &self.0; //.to_str().unwrap();
+		println!("=2, path: {:?}", path);
+		let pub_tx_f = read_qr_2(path);
+		println!("=3");
+		Ok(Slate::deserialize_upgrade(&pub_tx_f)?)
+	}
+}

--- a/impls/src/adapters/qr.rs
+++ b/impls/src/adapters/qr.rs
@@ -17,8 +17,8 @@ use super::compress::{compress, decompress, CompressionFormat};
 /// File Output 'plugin' implementation
 use crate::libwallet::{Error, ErrorKind, Slate, SlateVersion, VersionedSlate};
 use crate::{SlateGetter, SlatePutter};
-use image::{open, Luma};
-use qr_code::QrCode;
+use image::Luma;
+use qrcode::QrCode;
 use quircs;
 use std::path::PathBuf;
 
@@ -29,9 +29,7 @@ const COMPRESS_METHOD: CompressionFormat = CompressionFormat::Gzip;
 pub struct QrToSlate(pub PathBuf);
 
 fn save2qr(data: &str, path_save: &str) {
-	println!("--1");
-
-	println!("Data: {:?}", data.len());
+	let compressed_data = compress(data, mode);
 
 	//let data_compressed = compress(data, COMPRESS_METHOD);
 	//println!("Data Compressed: {:?}", data_compressed.len());
@@ -40,12 +38,12 @@ fn save2qr(data: &str, path_save: &str) {
 	println!("--2");
 	// Render the bits into an image.
 
-	let b = code.to_vec();
+	//let b = code.to_colors();
 
-	//let image = code.render::<Luma<u8>>().build();
+	let img = code.render::<Luma<u8>>().build();
 	println!("--3");
 	// Save the image.
-	image.save(path_save).unwrap();
+	img.save(path_save).unwrap();
 	println!("--4");
 }
 
@@ -75,22 +73,22 @@ fn read_qr_2(path_read: &PathBuf) -> String {
 	String::from("aa")
 }
 
-fn read_qr(path_read: &PathBuf) -> String {
-	println!("==1");
-	// Load the PNG image
-	let img = image::open(path_read).unwrap().to_rgb8();
+// fn read_qr(path_read: &PathBuf) -> String {
+// 	println!("==1");
+// 	// Load the PNG image
+// 	let img = image::open(path_read).unwrap().to_rgb8();
 
-	println!("==2: {:?}", img.to_vec().len());
-	// Convert the PNG image to a 2D binary matrix representation of the QR code
-	let qr_matrix = qrcode::QrCode::new(img.to_vec()).unwrap();
-	println!("==3");
-	// Get the data encoded in the QR code
-	let string = qr_matrix.render().light_color(' ').dark_color('#').build();
-	println!("==4");
-	println!("QR code data: {}", string);
+// 	println!("==2: {:?}", img.to_vec().len());
+// 	// Convert the PNG image to a 2D binary matrix representation of the QR code
+// 	let qr_matrix = QrCode::new(img.to_vec()).unwrap();
+// 	println!("==3");
+// 	// Get the data encoded in the QR code
+// 	let string = qr_matrix.render().light_color(' ').dark_color('#').build();
+// 	println!("==4");
+// 	println!("QR code data: {}", string);
 
-	string
-}
+// 	string
+// }
 
 impl SlatePutter for QrToSlate {
 	fn put_tx(&self, slate: &Slate) -> Result<(), Error> {

--- a/impls/src/adapters/qr.rs
+++ b/impls/src/adapters/qr.rs
@@ -88,15 +88,19 @@ fn save2qr(data: &str, path_save: &str, receive_op: bool) -> Result<(), Error> {
 	compressed_data_header.extend(compressed_data);
 
 	// The response file is larger than send, so we limit to different scales
-	let scalar: f32 = if receive_op { 1.0 } else { 5.0 / 9.0 };
+	let (scalar, num_scalar) = if receive_op {
+		(1.0, 2)
+	} else {
+		(50.0 / 89.0, 1)
+	};
 
 	let num_out = data.matches("commit").count();
 	let num_ele: f32 = compressed_data_header.len() as f32;
 
 	// If have more than 4 commits => use more than 2 outputs to generate, because of that the QR can't be generated
-	// Also, the limit to QR is 2335 elements, so the response file is almost 1.8 = 9/5 biggest than the Send slate_json.
-	// So we limit the message size to be sent by 5 / 9 = length / (9/5)
-	if num_out > 3 || num_ele > LIMIT_QR_BIN * scalar {
+	// Also, the limit to QR is 2335 elements, so the response file is almost 1.78 = 89/50 biggest than the Send slate_json.
+	// So we limit the message size to be sent by 50 / 89 = length / (89/50)
+	if num_out > 3 * num_scalar || num_ele > LIMIT_QR_BIN * scalar {
 		error!("DataTooLong to generate the QR code! Try to perform the transaction by another method. The size of compressed Slate is: {:?}. The number of Outputs used is: {:?}",
 		num_ele,
 		num_out);

--- a/impls/src/lib.rs
+++ b/impls/src/lib.rs
@@ -44,7 +44,7 @@ pub mod tor;
 
 pub use crate::adapters::{
 	create_sender, EmojiSlate, HttpSlateSender, KeybaseAllChannels, KeybaseChannel, PathToSlate,
-	SlateGetter, SlatePutter, SlateReceiver, SlateSender,
+	QrToSlate, SlateGetter, SlatePutter, SlateReceiver, SlateSender,
 };
 pub use crate::backends::{wallet_db_exists, LMDBBackend};
 pub use crate::error::{Error, ErrorKind};

--- a/impls/src/lib.rs
+++ b/impls/src/lib.rs
@@ -44,7 +44,7 @@ pub mod tor;
 
 pub use crate::adapters::{
 	create_sender, EmojiSlate, HttpSlateSender, KeybaseAllChannels, KeybaseChannel, PathToSlate,
-	QrToSlate, SlateGetter, SlatePutter, SlateReceiver, SlateSender,
+	QrToSlate, SlateGetter, SlatePutter, SlateReceiver, SlateSender, RESPONSE_EXTENTION,
 };
 pub use crate::backends::{wallet_db_exists, LMDBBackend};
 pub use crate::error::{Error, ErrorKind};

--- a/impls/src/lib.rs
+++ b/impls/src/lib.rs
@@ -43,8 +43,9 @@ pub mod test_framework;
 pub mod tor;
 
 pub use crate::adapters::{
-	create_sender, EmojiSlate, HttpSlateSender, KeybaseAllChannels, KeybaseChannel, PathToSlate,
-	QrToSlate, SlateGetter, SlatePutter, SlateReceiver, SlateSender, RESPONSE_EXTENTION,
+	create_sender, EmojiSlate, Header, HttpSlateSender, KeybaseAllChannels, KeybaseChannel,
+	PathToSlate, QrToSlate, SlateGetter, SlatePutter, SlateReceiver, SlateSender, EMOJI_VERSION,
+	QR_VERSION, RESPONSE_EXTENTION,
 };
 pub use crate::backends::{wallet_db_exists, LMDBBackend};
 pub use crate::error::{Error, ErrorKind};

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -249,6 +249,10 @@ pub enum ErrorKind {
 	#[fail(display = "SQLite Error")]
 	SQLiteError(String),
 
+	/// QR Command line argument error
+	#[fail(display = "QR Error")]
+	QRArgumentError,
+
 	/// Other
 	#[fail(display = "Generic error: {}", _0)]
 	GenericError(String),

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -250,8 +250,12 @@ pub enum ErrorKind {
 	SQLiteError(String),
 
 	/// QR Command line argument error
-	#[fail(display = "QR Error")]
+	#[fail(display = "Argument QR Error")]
 	QRArgumentError,
+
+	/// QR Command line argument error
+	#[fail(display = "Data Too Long QR Error")]
+	DataTooLongQRError,
 
 	/// Other
 	#[fail(display = "Generic error: {}", _0)]

--- a/src/bin/epic-wallet.yml
+++ b/src/bin/epic-wallet.yml
@@ -131,6 +131,7 @@ subcommands:
               - self
               - keybase
               - emoji
+              - qr
             default_value: http
             takes_value: true
         - dest:
@@ -181,10 +182,11 @@ subcommands:
             possible_values:
               - file
               - emoji
+              - qr
             default_value: file
             takes_value: true
         - input:
-            help: Partial transaction to process, expects the sender's transaction file or emoji string.
+            help: Partial transaction to process, expects the sender's transaction file, emoji, qr string.
             short: i
             long: input
             takes_value: true
@@ -198,6 +200,7 @@ subcommands:
             possible_values:
               - file
               - emoji
+              - qr
             default_value: file
             takes_value: true
         - input:


### PR DESCRIPTION
# Description

Adding transaction method via QR code.

This method is based on sending via File. having the same behavior.

The upload file is generated with `name.png`.
The response file is appended to `response_` at the beginning of the file resulting in `response_name.png`.

This method is very limited in the amount of characters it can generate in the QR image. Thus being more of an experimental method than something practical. Works for low-moderate transactions and

In addition, it has the same compression as the Emoji method.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (miscellaneous changes e.g. modifying .gitignore)
- [ ] Build (Affect build components like build tool, ci pipeline, dependencies, project version)
- [ ] Docs (documentation update)

# How Has This Been Tested?

Let's use the same test codes we have for the other methods. That are:

- [x] Cucumber tests
- [x] Random Wallet test

# Relevant notes

Any transaction that uses more than 1 output data will exceed the limit that QR can handle, which is 2330 values in the compressed array. Thus returning a panic.

I strongly recommend using the `smallest` method together with the method so that the code will try to use fewer outputs.