### PR TITLE
adding subscription interval arg to cli and toml

### DIFF
--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -502,8 +502,8 @@ where
 				.1
 				.into_iter()
 				.map(|mut t| {
-					t.confirmation_ts = Some(Utc.ymd(2019, 1, 15).and_hms(16, 1, 26));
-					t.creation_ts = Utc.ymd(2019, 1, 15).and_hms(16, 1, 26);
+					t.confirmation_ts = Some(Utc.with_ymd_and_hms(2019, 1, 15, 16, 1, 26).unwrap());
+					t.creation_ts = Utc.with_ymd_and_hms(2019, 1, 15, 16, 1, 26).unwrap();
 					t
 				})
 				.collect();

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -67,10 +67,7 @@ pub trait OwnerRpc: Sync + Send {
 	# , false, 4, false, false, false, false);
 	```
 	*/
-	#[deprecated(
-		since = "3.0.0",
-		note = "The V2 Owner API (OwnerRpc) will be removed in epic-wallet 4.0.0. Please migrate to the V3 (OwnerRpcS) API as soon as possible."
-	)]
+
 	fn accounts(&self) -> Result<Vec<AcctPathMapping>, ErrorKind>;
 
 	/**

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -170,15 +170,19 @@ pub struct EpicboxConfig {
 	pub epicbox_protocol_unsecure: Option<bool>,
 	/// Epicbox address id
 	pub epicbox_address_index: Option<u32>,
+	/// Duration of the epicbox listener subscribe update interval in seconds,
+	/// no less than 5 and no more than 120 seconds.
+	pub epicbox_listener_interval: Option<u64>,
 }
 
 impl Default for EpicboxConfig {
 	fn default() -> EpicboxConfig {
 		EpicboxConfig {
-			epicbox_domain: "epicbox.io".to_owned(),
+			epicbox_domain: "epicbox.epic.tech".to_owned(),
 			epicbox_port: Some(443),
 			epicbox_protocol_unsecure: Some(false),
 			epicbox_address_index: Some(0),
+			epicbox_listener_interval: Some(10),
 		}
 	}
 }
@@ -209,7 +213,7 @@ pub struct GlobalWalletConfigMembers {
 	pub wallet: WalletConfig,
 	/// Tor config
 	pub tor: Option<TorConfig>,
-	/// Tor config
+	/// Epicbox config
 	pub epicbox: Option<EpicboxConfig>,
 	/// Logging config
 	pub logging: Option<LoggingConfig>,

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -130,6 +130,7 @@ where
 /// Arguments for listen command
 pub struct ListenArgs {
 	pub method: String,
+	pub interval: Option<u64>,
 }
 
 pub fn listen<L, C, K>(
@@ -161,15 +162,19 @@ where
 			wallet.clone(),
 			keychain_mask.clone(),
 			epicbox_config.clone(),
+			args.interval,
 		),
 		method => {
 			return Err(ErrorKind::ArgumentError(format!(
-				"No listener for method \"{}\".",
-				method
+				"No listener for method {}",
+				method.clone()
 			))
 			.into());
 		}
 	};
+
+	debug!("{}", args.method.clone());
+	debug!("{}", args.interval.unwrap_or(10));
 
 	if let Err(e) = res {
 		return Err(ErrorKind::LibWallet(e.kind(), e.cause_string()).into());

--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -165,7 +165,7 @@ impl EpicboxListenChannel {
 		};
 		let (tx, _rx): (Sender<bool>, Receiver<bool>) = channel();
 
-		info!("Connecting to the epicbox server at {} ..", url.clone());
+		debug!("Connecting to the epicbox server at {} ..", url.clone());
 		let (socket, _response) = connect(url.clone()).expect(CONNECTION_ERR_MSG);
 		let publisher = EpicboxPublisher::new(address.clone(), sec_key, socket, tx)?;
 
@@ -292,7 +292,7 @@ where
 			),
 		}
 	};
-	info!("Connecting to the epicbox server at {} ..", url.clone());
+	debug!("Connecting to the epicbox server at {} ..", url.clone());
 	let (socket, _) = connect(url.clone()).expect(CONNECTION_ERR_MSG);
 
 	let publisher = EpicboxPublisher::new(address.clone(), sec_key, socket, tx)?;
@@ -475,7 +475,7 @@ where
 			if slate.tx.inputs().len() == 0 {
 				// TODO: invoicing
 			} else {
-				debug!("foreign::receive_tx");
+				info!("Received new transaction (foreign::receive_tx)");
 				let ret_slate = foreign::receive_tx(
 					&mut **w,
 					self.keychain_mask.as_ref(),
@@ -489,8 +489,10 @@ where
 
 			Ok(false)
 		} else {
-			debug!("owner::finalize_tx and owner::post_tx");
+			info!("Finalize transaction (owner::finalize_tx)");
 			let slate = owner::finalize_tx(&mut **w, self.keychain_mask.as_ref(), slate)?;
+
+			info!("Post transaction to the network (owner::post_tx)");
 			owner::post_tx(w.w2n_client(), &slate.tx, false)?;
 			Ok(true)
 		}
@@ -767,7 +769,7 @@ impl EpicboxBroker {
 					.map_err(|_| error!("error attempting challenge!"))
 					.unwrap();
 
-				info!("Refresh epicbox subscription (interval: {:?})", duration);
+				debug!("Refresh epicbox subscription (interval: {:?})", duration);
 				if first_run {
 					std::thread::sleep(duration);
 					first_run = false;

--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -40,6 +40,7 @@ use std::thread::JoinHandle;
 use crate::libwallet::api_impl::foreign;
 use crate::libwallet::api_impl::owner;
 use std::net::TcpStream;
+use std::string::ToString;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread::spawn;
 use tungstenite::connect;
@@ -60,6 +61,12 @@ use tungstenite::{Error as ErrorTungstenite, Message};
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+const CONNECTION_ERR_MSG: &str =
+	"\nCan't connect to the epicbox server!\nCheck your epic-wallet.toml settings\n";
+const DEFAULT_INTERVAL: u64 = 10;
+const MIN_INTERVAL: u64 = 2;
+const MAX_INTERVAL: u64 = 120;
 
 /// Epicbox 'plugin' implementation
 pub enum CloseReason {
@@ -95,8 +102,9 @@ pub struct EpicboxChannel {
 
 #[derive(Clone)]
 pub struct EpicboxListenChannel {
-	_priv: (), // makes KeybaseAllChannels unconstructable without checking for existence of keybase executable
+	_priv: (),
 }
+
 impl EpicboxListenChannel {
 	pub fn new() -> Result<EpicboxListenChannel, Error> {
 		Ok(EpicboxListenChannel { _priv: () })
@@ -106,13 +114,14 @@ impl EpicboxListenChannel {
 		wallet: Arc<Mutex<Box<dyn WalletInst<'static, L, C, K> + 'static>>>,
 		keychain_mask: Arc<Mutex<Option<SecretKey>>>,
 		epicbox_config: EpicboxConfig,
+		interval_arg: Option<u64>,
 	) -> Result<(), Error>
 	where
 		L: WalletLCProvider<'static, C, K> + 'static,
 		C: NodeClient + 'static,
 		K: Keychain + 'static,
 	{
-		let (address, sec_key) = {
+		let (address, sec_key, interval) = {
 			let a_keychain = keychain_mask.clone();
 			let a_wallet = wallet.clone();
 			let mask = a_keychain.lock();
@@ -131,7 +140,13 @@ impl EpicboxListenChannel {
 				Some(epicbox_config.epicbox_domain.clone()),
 				epicbox_config.epicbox_port,
 			);
-			(address, sec_key)
+
+			let mut interval = interval_arg;
+			if interval.is_none() {
+				interval = epicbox_config.epicbox_listener_interval
+			}
+
+			(address, sec_key, interval)
 		};
 		let url = {
 			let cloned_address = address.clone();
@@ -149,7 +164,7 @@ impl EpicboxListenChannel {
 			}
 		};
 		let (tx, _rx): (Sender<bool>, Receiver<bool>) = channel();
-		let (socket, _response) = connect(url.clone()).expect("Can't connect to epicbox server!");
+		let (socket, _response) = connect(url.clone()).expect(CONNECTION_ERR_MSG);
 		let publisher = EpicboxPublisher::new(address.clone(), sec_key, socket, tx)?;
 
 		let mut subscriber = EpicboxSubscriber::new(&publisher)?;
@@ -159,9 +174,11 @@ impl EpicboxListenChannel {
 		let km = mask.clone();
 		let controller = EpicboxController::new(container, cpublisher, wallet, km)
 			.expect("Could not init epicbox listener!");
-		warn!("Epicbox listener started.");
+
+		warn!("Starting epicbox listener for {}:", address);
+
 		subscriber
-			.start(controller)
+			.start(controller, interval)
 			.expect("Could not start epicbox listener!");
 		Ok(())
 	}
@@ -237,7 +254,7 @@ where
 	C: NodeClient + 'static,
 	K: Keychain + 'static,
 {
-	let (address, sec_key) = {
+	let (address, sec_key, interval) = {
 		let a_wallet = wallet.clone();
 		let mut w_lock = a_wallet.lock();
 		let lc = w_lock.lc_provider()?;
@@ -249,12 +266,14 @@ where
 			.unwrap();
 		let pub_key = PublicKey::from_secret_key(k.secp(), &sec_key).unwrap();
 
+		let interval: Option<u64> = config.epicbox_listener_interval;
+
 		let address = EpicboxAddress::new(
 			pub_key.clone(),
 			Some(config.epicbox_domain.clone()),
 			config.epicbox_port,
 		);
-		(address, sec_key)
+		(address, sec_key, interval)
 	};
 	let url = {
 		let cloned_address = address.clone();
@@ -271,7 +290,7 @@ where
 			),
 		}
 	};
-	let (socket, _) = connect(url.clone()).expect("Can't connect to epicbox server");
+	let (socket, _) = connect(url.clone()).expect(CONNECTION_ERR_MSG);
 
 	let publisher = EpicboxPublisher::new(address.clone(), sec_key, socket, tx)?;
 	let subscriber = EpicboxSubscriber::new(&publisher)?;
@@ -284,7 +303,7 @@ where
 			.expect("Could not init epicbox controller!");
 
 		csubscriber
-			.start(controller)
+			.start(controller, interval)
 			.expect("Could not start epicbox controller!");
 		()
 	});
@@ -296,6 +315,7 @@ where
 		handle,
 	}))
 }
+
 impl Listener for EpicboxListener {
 	/// keep :)
 	fn interface(&self) -> ListenerInterface {
@@ -324,7 +344,6 @@ impl EpicboxPublisher {
 	pub fn new(
 		address: EpicboxAddress,
 		secret_key: SecretKey,
-
 		socket: WebSocket<MaybeTlsStream<TcpStream>>,
 		tx: Sender<bool>,
 	) -> Result<Self, Error> {
@@ -548,7 +567,11 @@ where
 	}
 }
 pub trait Subscriber {
-	fn start<P, L, C, K>(&mut self, handler: EpicboxController<P, L, C, K>) -> Result<(), Error>
+	fn start<P, L, C, K>(
+		&mut self,
+		handler: EpicboxController<P, L, C, K>,
+		interval: Option<u64>,
+	) -> Result<(), Error>
 	where
 		P: Publisher,
 		L: WalletLCProvider<'static, C, K> + 'static,
@@ -557,7 +580,11 @@ pub trait Subscriber {
 	fn stop(&self);
 }
 impl Subscriber for EpicboxSubscriber {
-	fn start<P, L, C, K>(&mut self, handler: EpicboxController<P, L, C, K>) -> Result<(), Error>
+	fn start<P, L, C, K>(
+		&mut self,
+		handler: EpicboxController<P, L, C, K>,
+		interval: Option<u64>,
+	) -> Result<(), Error>
 	where
 		P: Publisher,
 		L: WalletLCProvider<'static, C, K> + 'static,
@@ -565,7 +592,7 @@ impl Subscriber for EpicboxSubscriber {
 		K: Keychain + 'static,
 	{
 		self.broker
-			.subscribe(&self.address, &self.secret_key, handler)?;
+			.subscribe(&self.address, &self.secret_key, handler, interval)?;
 		Ok(())
 	}
 
@@ -607,6 +634,7 @@ impl EpicboxBroker {
 		address: &EpicboxAddress,
 		secret_key: &SecretKey,
 		handler: EpicboxController<P, L, C, K>,
+		interval: Option<u64>,
 	) -> Result<(), Error>
 	where
 		P: Publisher,
@@ -664,8 +692,15 @@ impl EpicboxBroker {
 										error!("Error attempting to subscribe!");
 									})
 									.unwrap();
-								//wait one minute before start new subscription
-								let duration = std::time::Duration::from_secs(60);
+
+								// wait _interval_ seconds between subscriptions
+								let mut seconds = interval.unwrap_or(0);
+								if (MIN_INTERVAL < seconds) | (seconds < MAX_INTERVAL) {
+									seconds = DEFAULT_INTERVAL
+								}
+								let duration = std::time::Duration::from_secs(seconds);
+
+								info!("Sleeping for {:?}..", duration);
 								std::thread::sleep(duration);
 								new_challenge = true;
 							}
@@ -685,7 +720,7 @@ impl EpicboxBroker {
 								) {
 									Ok(x) => x,
 									Err(e) => {
-										error!("{}", e);
+										error!("{}", e.to_string());
 										return Ok(());
 									}
 								};

--- a/src/bin/epic-wallet.yml
+++ b/src/bin/epic-wallet.yml
@@ -81,9 +81,9 @@ subcommands:
             takes_value: true
             default_value: "10"
             possible_values:
+             - "2"
              - "5"
              - "10"
-             - "20"
              - "30"
              - "60"
              - "120"

--- a/src/bin/epic-wallet.yml
+++ b/src/bin/epic-wallet.yml
@@ -74,6 +74,19 @@ subcommands:
               - epicbox
             default_value: http
             takes_value: true
+        - interval:
+            help: Epicbox listener update interval duration in seconds
+            short: i
+            long: interval
+            takes_value: true
+            default_value: "10"
+            possible_values:
+             - "5"
+             - "10"
+             - "20"
+             - "30"
+             - "60"
+             - "120"
         - no_tor:
             help: Don't start TOR listener when starting HTTP listener
             short: n

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -351,12 +351,16 @@ pub fn parse_listen_args(
 	if let Some(port) = args.value_of("port") {
 		config.api_listen_port = port.parse().unwrap();
 	}
+
+	let interval = parse_u64_or_none(args.value_of("interval"));
 	let method = parse_required(args, "method")?;
+
 	if args.is_present("no_tor") {
 		tor_config.use_tor_listener = false;
 	}
 	Ok(command::ListenArgs {
 		method: method.to_owned(),
+		interval,
 	})
 }
 
@@ -389,7 +393,7 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 		Ok(a) => a,
 		Err(e) => {
 			let msg = format!(
-				"Could not parse amount as a number with optional decimal point. e={}",
+				"Could not parse amount as a number with optional decimal point. e={:?}",
 				e
 			);
 			return Err(ParseError::ArgumentError(msg));
@@ -555,9 +559,9 @@ pub fn parse_finalize_args(args: &ArgMatches) -> Result<command::FinalizeArgs, P
 	Ok(command::FinalizeArgs {
 		method: method.to_string(),
 		input: input.to_owned(),
-		fluff: fluff,
-		nopost: nopost,
 		dest: dest_file.to_owned(),
+		nopost,
+		fluff,
 	})
 }
 
@@ -570,7 +574,7 @@ pub fn parse_issue_invoice_args(
 		Ok(a) => a,
 		Err(e) => {
 			let msg = format!(
-				"Could not parse amount as a number with optional decimal point. e={}",
+				"Could not parse amount as a number with optional decimal point. e={:?}",
 				e
 			);
 			return Err(ParseError::ArgumentError(msg));
@@ -915,7 +919,7 @@ where
 			node_client,
 		)
 		.unwrap_or_else(|e| {
-			eprintln!("{}", e);
+			eprintln!("{:?}", e);
 			std::process::exit(1);
 		});
 


### PR DESCRIPTION
Add option to customize the time interval between new epicbox subscriptions called by user wallet (subscriber).

There is new variable in the `epic-wallet.toml` file
`epicbox_listener_interval` with default value set to `10` seconds.

In epic-wallet CLI when running listener now it is possible to override that setting with `-i` or `--interval` flag:

`./epic-wallet listen -method epicbox --interval 5`

There is a hardcoded range between `2` and `120` seconds, providing values out of that range will set them to default `10` seconds.

Some debug prints improvements in this commit.