### PR TITLE
remove default interval value

### DIFF
--- a/src/bin/epic-wallet.yml
+++ b/src/bin/epic-wallet.yml
@@ -79,7 +79,6 @@ subcommands:
             short: i
             long: interval
             takes_value: true
-            default_value: "10"
             possible_values:
              - "2"
              - "5"


### PR DESCRIPTION
default setting from `epic-wallet.yaml` file was overriding `epic-wallet.toml`  `epicbox_listener_interval` value.