### PR TITLE
Change default epicbox address to epicbox.epic.tech

### DIFF
--- a/libwallet/src/epicbox_address.rs
+++ b/libwallet/src/epicbox_address.rs
@@ -23,7 +23,7 @@ const EPICBOX_ADDRESS_VERSION_MAINNET: [u8; 2] = [1, 0];
 const EPICBOX_ADDRESS_VERSION_TESTNET: [u8; 2] = [1, 136];
 
 const EPICBOX_ADDRESS_REGEX: &str = r"^(epicbox://)?(?P<public_key>[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{52})(@(?P<domain>[a-zA-Z0-9\.]+)(:(?P<port>[0-9]*))?)?$";
-const DEFAULT_EPICBOX_DOMAIN: &str = "epicbox.io";
+const DEFAULT_EPICBOX_DOMAIN: &str = "epicbox.epic.tech";
 pub const DEFAULT_EPICBOX_PORT_80: u16 = 80;
 pub const DEFAULT_EPICBOX_PORT_443: u16 = 443;
 


### PR DESCRIPTION
With the changes located at  https://github.com/EpicCash/epicbox/pull/1, this resolves epicbox domain discernment, in cases where it is not supplied in `epic-wallet send`. (i.e. `./epic-wallet send -d <es-address> -m epicbox`)

Without this change, web address is populated with the non-existent `epicbox.io`. 

This should probably be expanded to check a list of valid epicbox locations. I can add that functionality to this commit, if desired. 

Alternative route would be to reference a DNS TXT Record, for a list of available epicbox services, or something of that sort.