### PR TITLE
Only subscribe on connect/reconnect, remove refresh interval

### DIFF
--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -130,7 +130,6 @@ where
 /// Arguments for listen command
 pub struct ListenArgs {
 	pub method: String,
-	pub interval: Option<u64>,
 }
 
 pub fn listen<L, C, K>(
@@ -165,7 +164,6 @@ where
 					wallet.clone(),
 					keychain_mask.clone(),
 					epicbox_config.clone(),
-					args.interval,
 				);
 				warn!("try to reconnect to epicbox");
 				match listener {
@@ -196,7 +194,6 @@ where
 	};
 
 	debug!("{}", args.method.clone());
-	debug!("{}", args.interval.unwrap_or(10));
 
 	if let Err(e) = res {
 		return Err(ErrorKind::LibWallet(e.kind(), e.cause_string()).into());

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -352,7 +352,6 @@ pub fn parse_listen_args(
 		config.api_listen_port = port.parse().unwrap();
 	}
 
-	let interval = parse_u64_or_none(args.value_of("interval"));
 	let method = parse_required(args, "method")?;
 
 	if args.is_present("no_tor") {
@@ -360,7 +359,6 @@ pub fn parse_listen_args(
 	}
 	Ok(command::ListenArgs {
 		method: method.to_owned(),
-		interval,
 	})
 }
 


### PR DESCRIPTION
- Previously, epic-wallet was unsubscribing, and re-subscribing every time a challenge was received from epicbox over WS
- This was unnecessary, and subscription only needs to happen once per connection (provided connection remains alive)
- This commit moves initial subscription from a challenge response, to central `Subscribe` function

These changes have been extensively tested by EpicBox Server chat testers, and plays nicely with https://github.com/fastepic/epicboxnodejs.