### PR TITLE
Don't exit epicbox listener on >= 5 reconnections

### DIFF
--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -158,7 +158,6 @@ where
 			KeybaseAllChannels::new()?.listen(wallet.clone(), keychain_mask.clone(), config.clone())
 		}
 		"epicbox" => {
-			let mut reconnect = 0;
 			loop {
 				let listener = EpicboxListenChannel::new()?.listen(
 					wallet.clone(),
@@ -167,22 +166,15 @@ where
 				);
 				warn!("try to reconnect to epicbox");
 				match listener {
-					Ok(_) => {
-						reconnect = 0;
-						()
-					}
+					Ok(_) => (),
 					Err(_e) => {
-						if reconnect >= 5 {
-							break;
-						} else {
-							reconnect += 1;
-						}
+						// error handled in adapter, no need to print here
+						()
 					}
 				}
 				let duration = std::time::Duration::from_secs(20);
 				std::thread::sleep(duration);
 			}
-			Ok(())
 		}
 		method => {
 			return Err(ErrorKind::ArgumentError(format!(


### PR DESCRIPTION
- This was causing listener to exit gracefully after 5 reconnection attempts.  This can happen naturally, and shouldn't force wallets to close
- This behavior no longer occurs, and listener persists, with these portions of code removed