### PR TITLE
Fix reconnection counter, properly reset

### DIFF
--- a/controller/src/error.rs
+++ b/controller/src/error.rs
@@ -107,6 +107,9 @@ pub enum ErrorKind {
 	/// Other
 	#[fail(display = "Generic error: {}", _0)]
 	GenericError(String),
+
+	#[fail(display = "Too many unsuccessful attempts at reconnection")]
+	EpicboxReconnectLimit,
 }
 
 impl Fail for Error {


### PR DESCRIPTION
- Prior to this change, 'reconnect' in controller/src/command.rs was not clearing to 0
- Result was that in cases of non-fatal protocol errors, epic-wallet was quitting listening mode after 10-15 minutes
- These changes add a new error type for this specific type of reconnection-based error
- Additionally, wallet will only quit after 5+1 failed attempts at listener connection
- In event a proper connection is made, and we receive data over protocol from epicbox, counter is now reset properly