### PR TITLE
Fixes decoding emoji slates that contain a slate with non-ASCII characters

### DIFF
--- a/impls/src/adapters/emoji.rs
+++ b/impls/src/adapters/emoji.rs
@@ -1103,7 +1103,7 @@ impl EmojiSlate {
 	}
 
 	fn translate2string(&self, emoji_string: &str) -> String {
-		let mut content = "".to_owned();
+		let mut content: Vec<u8> = Vec::new();
 		let mut bit_vec: BitVec = BitVec::new();
 
 		for i in 0..emoji_string.len() {
@@ -1140,10 +1140,10 @@ impl EmojiSlate {
 			for j in i..(i + 8) {
 				bit_vec_8b_slice.push(bit_vec[j]);
 			}
-			content.push(self.bitvec2byte(bit_vec_8b_slice) as char);
+			content.push(self.bitvec2byte(bit_vec_8b_slice));
 		}
 
-		return content;
+		return String::from_utf8(content).unwrap();
 	}
 
 	pub fn encode(&self, slate: &Slate) -> String {


### PR DESCRIPTION
Fixes decoding emoji slates that contain messages with non-ASCII characters.

This can be tested by running the following commands
`epic-wallet send -m emoji -g "😃" 1`
`epic-wallet receive -m emoji -i "..."`

Without this PR you'll get the following errors since participant messages containing non-ASCII characters, like `😃`, aren't decoded correctly.
```
ERROR verify_messages - participant message doesn't match signature. Message: "ð"
ERROR Error validating participant messages: Signature error: Optional participant messages do not match signatures
Wallet command failed: LibWallet Error: Signature error: Optional participant messages do not match signatures
```
