### PR TITLE
Fix OwnerAPI v2 failure to retrieve epicbox config

### DIFF
--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -163,7 +163,7 @@ impl Default for TorConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct EpicboxConfig {
 	/// Default epicbox Domain/Server
-	pub epicbox_domain: String,
+	pub epicbox_domain: Option<String>,
 	/// Connect to epicbox port 443 or 80
 	pub epicbox_port: Option<u16>,
 	/// Use to epicbox port 443 or 80
@@ -175,7 +175,7 @@ pub struct EpicboxConfig {
 impl Default for EpicboxConfig {
 	fn default() -> EpicboxConfig {
 		EpicboxConfig {
-			epicbox_domain: "epicbox.epic.tech".to_owned(),
+			epicbox_domain: Some("epicbox.epic.tech".to_owned()),
 			epicbox_port: Some(443),
 			epicbox_protocol_unsecure: Some(false),
 			epicbox_address_index: Some(0),

--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -146,7 +146,7 @@ impl EpicboxListenChannel {
 
 			let address = EpicboxAddress::new(
 				pub_key.clone(),
-				Some(epicbox_config.epicbox_domain.clone()),
+				epicbox_config.epicbox_domain.clone(),
 				epicbox_config.epicbox_port,
 			);
 
@@ -283,7 +283,7 @@ where
 
 		let address = EpicboxAddress::new(
 			pub_key.clone(),
-			Some(config.epicbox_domain.clone()),
+			config.epicbox_domain.clone(),
 			config.epicbox_port,
 		);
 		(address, sec_key)


### PR DESCRIPTION
When running `owner_api` and calling a v2 endpoint, epicbox config was not being considered at all, because v2 handler did not have access to the data.

This is true of `tor` cofnfig as well, and users on tor who might be using v2 should definitely be made aware.

In any case, this fixes the aforementioned issue and should enable anyone using v2 owner api to route properly through their desired `epicbox` instance.