### PR TITLE
Fix domain/port discernment for transfers routed through epicbox

### DIFF
--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -237,7 +237,6 @@ impl EpicboxChannel {
 
 		let vslate = VersionedSlate::into_version(slate.clone(), SlateVersion::V2);
 
-		warn!("<<<< in EpicboxChannel::send, dest({:?})", self.dest);
 		let _ = container
 			.lock()
 			.listener(ListenerInterface::Epicbox)
@@ -335,9 +334,7 @@ impl Listener for EpicboxListener {
 	}
 	/// post slate
 	fn publish(&self, slate: &VersionedSlate, to: &String) -> Result<(), Error> {
-		warn!(">>> in Listener::publish");
 		let address = EpicboxAddress::from_str(to)?;
-		warn!(">>> EboxAddr({:?})", address);
 		self.publisher.post_slate(slate, &address, true)
 	}
 
@@ -373,9 +370,6 @@ impl Publisher for EpicboxPublisher {
 		to: &EpicboxAddress,
 		close_connection: bool,
 	) -> Result<(), Error> {
-		warn!(">>>> in Publisher::post_slate");
-		//		let to = EpicboxAddress::from_str(&to.to_string())?;
-		warn!(">>>> to({:?}), self.addr({:?})", to, self.address);
 		self.broker
 			.post_slate(slate, &to, &self.address, &self.secret_key)?;
 		if close_connection {

--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -234,12 +234,15 @@ impl EpicboxChannel {
 
 		let vslate = VersionedSlate::into_version(slate.clone(), SlateVersion::V2);
 
-		let _ = container
+		let _ = match container
 			.lock()
 			.listener(ListenerInterface::Epicbox)
 			.unwrap()
 			.publish(&vslate, &self.dest)
-			.unwrap();
+		{
+			Ok(_) => (),
+			Err(e) => return Err(e),
+		};
 
 		let slate: Slate = VersionedSlate::into_version(slate.clone(), SlateVersion::V2).into();
 		Ok(slate)
@@ -538,10 +541,6 @@ where
 				amount_to_hr_string(slate.amount, false)
 			);
 		};
-
-		/*if from.address_type() == AddressType::Epicbox {
-			EpicboxAddress::from_str(&from.to_string()).expect("invalid epicbox address");
-		}*/
 
 		let result = self
 			.process_incoming_slate(Some(from.to_string()), &mut slate, tx_proof)

--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -22,10 +22,7 @@ use crate::libwallet::message::EncryptedMessage;
 use crate::util::secp::key::PublicKey;
 
 use crate::libwallet::wallet_lock;
-use crate::libwallet::{
-	address, Address, AddressType, EpicboxAddress, TxProof, DEFAULT_EPICBOX_PORT_443,
-	DEFAULT_EPICBOX_PORT_80,
-};
+use crate::libwallet::{address, Address, EpicboxAddress, TxProof};
 use crate::libwallet::{NodeClient, WalletInst, WalletLCProvider};
 
 use crate::Error;

--- a/libwallet/src/epicbox_address.rs
+++ b/libwallet/src/epicbox_address.rs
@@ -58,7 +58,7 @@ impl EpicboxAddress {
 		Self {
 			public_key: public_key.to_base58_check(version_bytes()),
 			domain: domain.unwrap_or(DEFAULT_EPICBOX_DOMAIN.to_string()),
-			port: port.unwrap_or(443),
+			port: port.unwrap_or(DEFAULT_EPICBOX_PORT_443),
 		}
 	}
 

--- a/libwallet/src/epicbox_address.rs
+++ b/libwallet/src/epicbox_address.rs
@@ -105,11 +105,9 @@ impl Address for EpicboxAddress {
 impl Display for EpicboxAddress {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{}", self.public_key)?;
-		if self.domain != DEFAULT_EPICBOX_DOMAIN || self.port != DEFAULT_EPICBOX_PORT_443 {
-			write!(f, "@{}", self.domain)?;
-			if self.port != DEFAULT_EPICBOX_PORT_443 {
-				write!(f, ":{}", self.port)?;
-			}
+		write!(f, "@{}", self.domain)?;
+		if self.port != DEFAULT_EPICBOX_PORT_443 {
+			write!(f, ":{}", self.port)?;
 		}
 		Ok(())
 	}

--- a/libwallet/src/epicbox_address.rs
+++ b/libwallet/src/epicbox_address.rs
@@ -83,11 +83,6 @@ impl Address for EpicboxAddress {
 			.name("port")
 			.map(|m| u16::from_str_radix(m.as_str(), 10).unwrap());
 
-		warn!(
-			">>> Parsing regex capture: pubkey({:?}),domain({:?}),port({:?})",
-			public_key, domain, port
-		);
-
 		let public_key = PublicKey::from_base58_check(&public_key, version_bytes())?;
 
 		Ok(EpicboxAddress::new(public_key, domain, port))


### PR DESCRIPTION
This PR includes 3 distinct fixes for `epic-wallet` usage when routing through `epicbox`.

**1. Silent overwriting of epicbox address domain & port**
- `EpicboxAddress::from_str()` was being called twice prior to sending. This function validates **and parses** our user-provided epicbox destination
-  Calling this function a second time on the same data caused a silent overwrite of `domain` and `port` in `str` portion of request (which includes our actual destination, after being parsed by regex)
- Result of all of this was some transactions being routed to `epicbox.epic.tech` unintentionally.

**2. User-provided port was not being passed through to JSON request**
- This was occurring due to a combination of no.1 above, and `Option` type not being unwrapped properly prior to sending to epicbox
- Default port of 443 was always substituted, so never created any noticeable problems

**3. `EpicboxAddress::stripped()` member function was written in such a way that default domain `epicbox.epic.tech` is removed from address**
- This has been fixed (with no real impact to epicbox), such that full `<pubkey>@<domain>` is always passed through in-full.