### PR TITLE
Gracefully handle invalid base58 encodings when calling 'send' cmd

### DIFF
--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -245,12 +245,14 @@ impl EpicboxChannel {
 
 		let vslate = VersionedSlate::into_version(slate.clone(), SlateVersion::V2);
 
-		let _ = container
+		let _ = match container
 			.lock()
 			.listener(ListenerInterface::Epicbox)
 			.unwrap()
-			.publish(&vslate, &self.dest)
-			.unwrap();
+			.publish(&vslate, &self.dest) {
+				Ok(_) => (),
+				Err(e) => return Err(e)
+			};
 
 		let slate: Slate = VersionedSlate::into_version(slate.clone(), SlateVersion::V2).into();
 		Ok(slate)


### PR DESCRIPTION
Issue is described thoroughly by @blacktyger in #88.

Panic was happening because we are calling 'unwrap()' on error.  The unwrap is useless here, except to cause a panic if `Result` returns any error. In cases where it doesn't, "unit type" is returned i.e. `()`.  This type cannot be unwrapped.

With these changes, sender will receive the following message:

```
Wallet command failed: LibWallet Error: Generic error: LibWallet Error: Invalid base58 checksum
```

Which is much more informative.

Thanks for noticing this tyger!