### PR TITLE
Revert ebox port changes, fixes encrypted data parsing error

### DIFF
--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -22,7 +22,9 @@ use crate::libwallet::message::EncryptedMessage;
 use crate::util::secp::key::PublicKey;
 
 use crate::libwallet::wallet_lock;
-use crate::libwallet::{address, Address, EpicboxAddress, TxProof};
+use crate::libwallet::{
+	address, Address, EpicboxAddress, TxProof, DEFAULT_EPICBOX_PORT_443, DEFAULT_EPICBOX_PORT_80,
+};
 use crate::libwallet::{NodeClient, WalletInst, WalletLCProvider};
 
 use crate::Error;
@@ -152,8 +154,16 @@ impl EpicboxListenChannel {
 		let url = {
 			let cloned_address = address.clone();
 			match epicbox_config.epicbox_protocol_unsecure.unwrap_or(false) {
-				true => format!("ws://{}:{}", cloned_address.domain, cloned_address.port),
-				false => format!("wss://{}:{}", cloned_address.domain, cloned_address.port),
+				true => format!(
+					"ws://{}:{}",
+					cloned_address.domain,
+					cloned_address.port.unwrap_or(DEFAULT_EPICBOX_PORT_80)
+				),
+				false => format!(
+					"wss://{}:{}",
+					cloned_address.domain,
+					cloned_address.port.unwrap_or(DEFAULT_EPICBOX_PORT_443)
+				),
 			}
 		};
 		let (tx, _rx): (Sender<bool>, Receiver<bool>) = channel();
@@ -238,10 +248,11 @@ impl EpicboxChannel {
 			.lock()
 			.listener(ListenerInterface::Epicbox)
 			.unwrap()
-			.publish(&vslate, &self.dest) {
-				Ok(_) => (),
-				Err(e) => return Err(e)
-			};
+			.publish(&vslate, &self.dest)
+		{
+			Ok(_) => (),
+			Err(e) => return Err(e),
+		};
 
 		let slate: Slate = VersionedSlate::into_version(slate.clone(), SlateVersion::V2).into();
 		Ok(slate)
@@ -282,8 +293,16 @@ where
 	let url = {
 		let cloned_address = address.clone();
 		match config.epicbox_protocol_unsecure.unwrap_or(false) {
-			true => format!("ws://{}:{}", cloned_address.domain, cloned_address.port),
-			false => format!("wss://{}:{}", cloned_address.domain, cloned_address.port),
+			true => format!(
+				"ws://{}:{}",
+				cloned_address.domain,
+				cloned_address.port.unwrap_or(DEFAULT_EPICBOX_PORT_80)
+			),
+			false => format!(
+				"wss://{}:{}",
+				cloned_address.domain,
+				cloned_address.port.unwrap_or(DEFAULT_EPICBOX_PORT_443)
+			),
 		}
 	};
 	debug!("Connecting to the epicbox server at {} ..", url.clone());

--- a/libwallet/src/epicbox_address.rs
+++ b/libwallet/src/epicbox_address.rs
@@ -42,7 +42,7 @@ pub enum AddressType {
 pub struct EpicboxAddress {
 	pub public_key: String,
 	pub domain: String,
-	pub port: u16,
+	pub port: Option<u16>,
 }
 
 pub trait Address: Debug + Display {
@@ -58,7 +58,7 @@ impl EpicboxAddress {
 		Self {
 			public_key: public_key.to_base58_check(version_bytes()),
 			domain: domain.unwrap_or(DEFAULT_EPICBOX_DOMAIN.to_string()),
-			port: port.unwrap_or(DEFAULT_EPICBOX_PORT_443),
+			port: port,
 		}
 	}
 
@@ -101,9 +101,10 @@ impl Display for EpicboxAddress {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{}", self.public_key)?;
 		write!(f, "@{}", self.domain)?;
-		if self.port != DEFAULT_EPICBOX_PORT_443 {
-			write!(f, ":{}", self.port)?;
+		if self.port.is_some() && self.port.unwrap() != DEFAULT_EPICBOX_PORT_443 {
+			write!(f, ":{}", self.port.unwrap())?;
 		}
+
 		Ok(())
 	}
 }


### PR DESCRIPTION
Changes committed in #90 included modification to `port` member of EpicboxAddress struct.  This was done to ensure proper communication of port through workflow from: config file -> address -> wire (and back). 

However, changing type of `port` member from `Option<u16>` to `u16`, affected the way Epicbox addresses are serialized and deserialized when being communicated between wallets/epicbox.

Big thanks to @blacktyger for finding this bug, as it breaks backward compat with other wallets, resulting in the following error message:

```
ERROR Unable to parse encrypted message 
```

As such, changes were reverted.  This may mean we need to fix the port discernment again, but I will test that later.  For now, default over 443 works.