### PR TITLE
[FIX] Improve epicbox address api calls

### DIFF
--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -2020,7 +2020,17 @@ where
 		keychain_mask: Option<&SecretKey>,
 		derivation_index: u32,
 	) -> Result<EpicboxAddress, Error> {
-		owner::get_public_address(self.wallet_inst.clone(), keychain_mask, derivation_index)
+		let epicbox_config_lock = self.epicbox_config.lock();
+		let epicbox_config = match epicbox_config_lock.clone() {
+			None => EpicboxConfig::default(),
+			Some(epicbox_config) => epicbox_config,
+		};
+		owner::get_public_address(
+			self.wallet_inst.clone(),
+			keychain_mask,
+			epicbox_config,
+			derivation_index,
+		)
 	}
 
 	/// Retrieve the public proof "addresses" associated with the active account at the

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -971,6 +971,7 @@ pub fn address<L, C, K>(
 	wallet: Arc<Mutex<Box<dyn WalletInst<'static, L, C, K>>>>,
 	g_args: &GlobalArgs,
 	keychain_mask: Option<&SecretKey>,
+	epicbox_config: EpicboxConfig,
 ) -> Result<(), Error>
 where
 	L: WalletLCProvider<'static, C, K> + 'static,
@@ -981,15 +982,18 @@ where
 		// Just address at derivation index 0 for now
 		let pub_key = api.get_public_proof_address(m, 0)?;
 		let result = address::onion_v3_from_pubkey(&pub_key);
-
 		let address = api.get_public_address(m, 0)?;
 
 		match result {
 			Ok(a) => {
 				println!();
-				println!("Address for account - {}", g_args.account);
+				println!("Epicbox address for account - {}", g_args.account);
 				println!("-------------------------------------");
-				println!("{}", address.public_key);
+				println!(
+					"{}@{}",
+					address.public_key,
+					epicbox_config.epicbox_domain.unwrap()
+				);
 				println!();
 				println!("Public Proof Address for account - {}", g_args.account);
 				println!("-------------------------------------");

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -24,6 +24,7 @@ use crate::epic_util::secp::key::SecretKey;
 use crate::epic_util::Mutex;
 
 use crate::api_impl::owner_updater::StatusMessage;
+use crate::config::EpicboxConfig;
 use crate::epic_keychain::{Identifier, Keychain};
 use crate::epic_util::secp::key::PublicKey;
 use crate::epicbox_address::EpicboxAddress;
@@ -104,6 +105,7 @@ where
 pub fn get_public_address<'a, L, C, K>(
 	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
 	keychain_mask: Option<&SecretKey>,
+	epicbox_config: EpicboxConfig,
 	index: u32,
 ) -> Result<EpicboxAddress, Error>
 where
@@ -116,8 +118,11 @@ where
 	let k = w.keychain(keychain_mask)?;
 	let sec_addr_key = address::address_from_derivation_path(&k, &parent_key_id, index)?;
 	let pub_key = PublicKey::from_secret_key(k.secp(), &sec_addr_key).unwrap();
-
-	Ok(EpicboxAddress::new(pub_key, Some("".to_string()), Some(0)))
+	Ok(EpicboxAddress::new(
+		pub_key,
+		Some(epicbox_config.epicbox_domain.unwrap()),
+		Some(epicbox_config.epicbox_port.unwrap()),
+	))
 }
 
 /// retrieve outputs

--- a/src/bin/epic-wallet.yml
+++ b/src/bin/epic-wallet.yml
@@ -381,7 +381,7 @@ subcommands:
   - recover:
       about: Displays a recovery phrase for the wallet. (use `init -r` to perform recovery)
   - address:
-      about: Display the wallet's payment proof address
+      about: Display the wallet's Epicbox public address, the payment proof address and the TOR address
   - scan:
       about: Checks a wallet's outputs against a live node, repairing and restoring missing outputs if required
       args:

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -1089,7 +1089,7 @@ where
 			let a = arg_parse!(parse_verify_proof_args(&args));
 			command::proof_verify(wallet, km, a)
 		}
-		("address", Some(_)) => command::address(wallet, &global_wallet_args, km),
+		("address", Some(_)) => command::address(wallet, &global_wallet_args, km, epicbox_config),
 		("scan", Some(args)) => {
 			let a = arg_parse!(parse_check_args(&args));
 			command::scan(wallet, km, a)


### PR DESCRIPTION
This commit improves api calls for:
- cli `epic-wallet address` command
- owner_api `get_public_address` call

Previously only `pub_key` was returned, after the changes we also have access to epicbox domain and port.

`src/bin/epic-wallet.yml` file was edited to improve `--help` flag and describe better what `address` command is returning.

closes #86 #74
