### PR TITLE
Fix where epicbox listener stop receiving txs.

### DIFF
--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -168,7 +168,7 @@ where
 					epicbox_config.clone(),
 					&mut reconnections,
 				);
-				warn!("try to reconnect to epicbox");
+				info!("Reconnect to epicbox");
 				match listener {
 					Err(e) => {
 						error!("Error in listener loop ({})", e);

--- a/impls/src/adapters/mod.rs
+++ b/impls/src/adapters/mod.rs
@@ -21,7 +21,7 @@ mod keybase;
 pub use self::emoji::EmojiSlate;
 pub use self::epicbox::{
 	Container, EpicboxBroker, EpicboxController, EpicboxListener, EpicboxPublisher,
-	EpicboxSubscriber, Listener, ListenerInterface, Subscriber,
+	EpicboxSubscriber, Listener, ListenerInterface,
 };
 pub use self::epicbox::{EpicboxChannel, EpicboxListenChannel};
 pub use self::file::PathToSlate;

--- a/impls/src/lib.rs
+++ b/impls/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::adapters::{
 	create_sender, Container, EmojiSlate, EpicboxBroker, EpicboxChannel, EpicboxController,
 	EpicboxListenChannel, EpicboxListener, EpicboxPublisher, EpicboxSubscriber, HttpSlateSender,
 	KeybaseAllChannels, KeybaseChannel, Listener, ListenerInterface, PathToSlate, SlateGetter,
-	SlatePutter, SlateReceiver, SlateSender, Subscriber,
+	SlatePutter, SlateReceiver, SlateSender,
 };
 pub use crate::backends::{wallet_db_exists, LMDBBackend};
 pub use crate::error::Error;


### PR DESCRIPTION
# Description

This fix solves the problem, where the epicbox listener does not refresh his subscription and blocks connection with the epicbox server. 

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)


Tested on MacOs.
24h listener run with repeating receive tx,
send -m epicbox/txs/outputs/scan/info during listener runs

