### PR TITLE
fix bug where get_kernel send the wrong format to node api

### DIFF
--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -171,7 +171,11 @@ impl NodeClient for HTTPNodeClient {
 		max_height: Option<u64>,
 	) -> Result<Option<(TxKernel, u64, u64)>, Error> {
 		let method = "get_kernel";
-		let params = json!([excess.0.as_ref().to_vec(), min_height, max_height]);
+		let params = json!([
+			util::to_hex(excess.0.as_ref().to_vec()),
+			min_height,
+			max_height
+		]);
 		// have to handle this manually since the error needs to be parsed
 		let url = format!("{}{}", self.node_url(), ENDPOINT);
 		let req = build_request(method, &params);


### PR DESCRIPTION
Fix a bug where the api call 'get_kernel' send wrong data. 
Requires now commitment as hex string and not index


- [x ] Bug fix (non-breaking change which fixes an issue)

Reproduce the error:
$: ./epic-wallet info
<img width="1322" alt="image" src="https://github.com/EpicCash/epic-wallet/assets/1593652/dea11d08-634f-4bcc-8ec5-cb1f9dca9968">
