### PR TITLE
Don't panic on re-subscribe error, remove 'expect' usage

### DIFF
--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -862,9 +862,12 @@ impl EpicboxBroker {
 									signature,
 								};
 
-								client
-									.sendv2(&request_sub)
-									.expect("Could not send subscribe request!");
+								match client.sendv2(&request_sub) {
+									Ok(()) => { /* do nothing */ },
+									Err(e) => {
+										 error!("Could not send subscribe request: {}", e.to_string());
+									}
+								};
 							}
 							_ => {}
 						}


### PR DESCRIPTION
Resolves the following error, introduced in #96:

```
thread 'main' panicked at 'Could not send subscribe request!: Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" })': /home/biz/EpicCash/epic-wallet/impls/src/adapters/epicbox.rs:867
```

Rust's `expect` closure can panic.  The replacement `match` statement here will not, preventing wallet from exiting.