### PR TITLE
Change 'unwrap' usage to '?' operator in controller/src/command.rs

### DIFF
--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -448,7 +448,7 @@ where
 	let method = args.method.as_str();
 	let mut slate;
 	if method == "emoji" {
-		slate = EmojiSlate().decode(&args.input.as_str()).unwrap();
+		slate = EmojiSlate().decode(&args.input.as_str())?;
 	} else {
 		slate = PathToSlate((&args.input).into()).get_tx()?;
 	}
@@ -889,7 +889,7 @@ where
 				return Ok(());
 			}
 			Some(f) => {
-				let mut tx_file = File::create(f.clone()).unwrap();
+				let mut tx_file = File::create(f.clone())?;
 				tx_file.write_all(json::to_string(&stored_tx).unwrap().as_bytes())?;
 				tx_file.sync_all()?;
 				info!("Dumped transaction data for tx {} to {}", args.id, f);
@@ -1038,7 +1038,7 @@ where
 		match result {
 			Ok(p) => {
 				// actually export proof
-				let mut proof_file = File::create(args.output_file.clone()).unwrap();
+				let mut proof_file = File::create(args.output_file.clone())?;
 				proof_file.write_all(json::to_string_pretty(&p).unwrap().as_bytes())?;
 				proof_file.sync_all()?;
 				warn!("Payment proof exported to {}", args.output_file);

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -588,8 +588,7 @@ where
 				.borrow()
 				.as_ref()
 				.unwrap()
-				.put_ser(&key, Serializable::OutputData(out))
-				.unwrap();
+				.put_ser(&key, Serializable::OutputData(out))?;
 		}
 
 		Ok(())
@@ -817,8 +816,7 @@ where
 			.borrow()
 			.as_ref()
 			.unwrap()
-			.put_ser(&tx_log_key, Serializable::TxLogEntry(tx_in))
-			.unwrap();
+			.put_ser(&tx_log_key, Serializable::TxLogEntry(tx_in))?;
 		Ok(())
 	}
 


### PR DESCRIPTION
usage of `?` operator was removed, and replaced with `unwrap()` which will panic if operation fails.

These changes were originally made in tokio, hyper, etc update in #95 

Purpose of this PR is just a reversion of these, to avoid panics in tx flow.