### PR TITLE
Remove subscribe interval from listener

### DIFF
--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -218,23 +218,13 @@ impl EpicboxChannel {
 
 		let container = Container::new(config.clone());
 
-		let (tx, rx): (Sender<bool>, Receiver<bool>) = channel();
+		let (tx, _rx): (Sender<bool>, Receiver<bool>) = channel();
 		let listener = start_epicbox(container.clone(), wallet, keychain_mask, config, tx).unwrap();
 
 		container
 			.lock()
 			.listeners
 			.insert(ListenerInterface::Epicbox, listener);
-		//warn!("Waitng for rx");
-
-		loop {
-			std::thread::sleep(std::time::Duration::from_secs(1));
-			if rx.recv().unwrap() {
-				break;
-			}
-		}
-
-		//warn!("After rx");
 
 		let vslate = VersionedSlate::into_version(slate.clone(), SlateVersion::V2);
 


### PR DESCRIPTION
Remove subscribe interval, executed by listener.
Remove unnecessary subscribe and interval code.

This fix is working only if the epixbox relay server has a reduced interval time.
If epixbox subscription interval is to high (see epicbox script "`setInterval(forIntervalChallenge, 3*60*1000);`"), then the listener is quitting the connection to epicbox relay server.


