### PR TITLE
Use explicitly versioned ring dependency (0.16.20)

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -20,7 +20,7 @@ serde_derive = "1"
 serde_json = "1"
 easy-jsonrpc-mw = "0.5.3"
 chrono = { version = "0.4.4", features = ["serde"] }
-ring = "^0.16"
+ring = "0.16.20"
 base64 = "0.9"
 ed25519-dalek = "=1.0.0-pre.1"
 

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -19,7 +19,7 @@ serde_derive = "1"
 serde_json = "1.0.69"
 log = "0.4"
 prettytable-rs = "0.10"
-ring = "^0.16"
+ring = "0.16.20"
 term = "0.5"
 
 tokio = { version = "1.32", features = ["full"] }

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -21,7 +21,7 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 log = "0.4"
-ring = "^0.16"
+ring = "0.16.20"
 
 uuid = { version = "0.7", features = ["serde", "v4"] }
 chrono = { version = "0.4.4", features = ["serde"] }


### PR DESCRIPTION
The rest of our codebase uses an explicit version here. There are many newer ring versions, so let's be sure they don't automatically update.