### PR TITLE
Add a From/To address field in wallet db

### DIFF
--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -338,7 +338,7 @@ where
 		foreign::verify_slate_messages(slate)
 	}
 
-	/// Recieve a tranaction created by another party, returning the modified
+	/// Receive a transaction created by another party, returning the modified
 	/// [`Slate`](../epic_wallet_libwallet/slate/struct.Slate.html) object, modified with
 	/// the recipient's output for the transaction amount, and public signature data. This slate can
 	/// then be sent back to the sender to finalize the transaction via the
@@ -360,7 +360,6 @@ where
 	/// * `dest_acct_name` - The name of the account into which the slate should be received. If
 	/// `None`, the default account is used.
 	/// * `message` - An optional participant message to include alongside the recipient's public
-	/// * `addr_from` - An optional field to store the sender address
 	/// ParticipantData within the slate. This message will include a signature created with the
 	/// recipient's private excess value, and will be publically verifiable. Note this message is for
 	/// the convenience of the participants during the exchange; it is not included in the final
@@ -387,7 +386,7 @@ where
 	///
 	/// // . . .
 	/// // Obtain a sent slate somehow
-	/// let result = api_foreign.receive_tx(&slate, None, None, None);
+	/// let result = api_foreign.receive_tx(&slate, None, None);
 	///
 	/// if let Ok(slate) = result {
 	///		// Send back to recipient somehow
@@ -400,7 +399,6 @@ where
 		slate: &Slate,
 		dest_acct_name: Option<&str>,
 		message: Option<String>,
-		addr_from: Option<String>,
 	) -> Result<Slate, Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let w = w_lock.lc_provider()?.wallet_inst()?;
@@ -411,13 +409,14 @@ where
 				Some(slate),
 			)?;
 		}
+
 		foreign::receive_tx(
 			&mut **w,
 			(&self.keychain_mask).as_ref(),
 			slate,
 			dest_acct_name,
 			message,
-			addr_from,
+			None,
 			self.doctest_mode,
 		)
 	}

--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -360,6 +360,7 @@ where
 	/// * `dest_acct_name` - The name of the account into which the slate should be received. If
 	/// `None`, the default account is used.
 	/// * `message` - An optional participant message to include alongside the recipient's public
+	/// * `addr_from` - An optional field to store the sender address
 	/// ParticipantData within the slate. This message will include a signature created with the
 	/// recipient's private excess value, and will be publically verifiable. Note this message is for
 	/// the convenience of the participants during the exchange; it is not included in the final
@@ -386,7 +387,7 @@ where
 	///
 	/// // . . .
 	/// // Obtain a sent slate somehow
-	/// let result = api_foreign.receive_tx(&slate, None, None);
+	/// let result = api_foreign.receive_tx(&slate, None, None, None);
 	///
 	/// if let Ok(slate) = result {
 	///		// Send back to recipient somehow
@@ -399,6 +400,7 @@ where
 		slate: &Slate,
 		dest_acct_name: Option<&str>,
 		message: Option<String>,
+		addr_from: Option<String>,
 	) -> Result<Slate, Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let w = w_lock.lc_provider()?.wallet_inst()?;
@@ -415,6 +417,7 @@ where
 			slate,
 			dest_acct_name,
 			message,
+			addr_from,
 			self.doctest_mode,
 		)
 	}

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -214,14 +214,14 @@ pub trait ForeignRpc {
 		"id": 1,
 		"params": [
 			{
-			"version_info": {
-				"version": 2,
-				"orig_version": 2,
-				"block_header_version": 6
-			},
-			"num_participants": 2,
-			"id": "0436430c-2b02-624c-2032-570501212b00",
-			"tx": {
+			  "version_info": {
+					"version": 2,
+					"orig_version": 2,
+					"block_header_version": 6
+			  },
+			  "num_participants": 2,
+			  "id": "0436430c-2b02-624c-2032-570501212b00",
+			  "tx": {
 				"offset": "d202964900000000d302964900000000d402964900000000d502964900000000",
 				"body": {
 					"inputs": [
@@ -270,8 +270,8 @@ pub trait ForeignRpc {
 			]
 		},
 		null,
-		"Thanks, Yeastplume",
-		"From Address String"
+		"Thanks, Yeastplume"
+
 		]
 	}
 	# "#
@@ -361,7 +361,6 @@ pub trait ForeignRpc {
 		slate: VersionedSlate,
 		dest_acct_name: Option<String>,
 		message: Option<String>,
-		addr_from: Option<String>,
 	) -> Result<VersionedSlate, Error>;
 
 	/**
@@ -561,7 +560,6 @@ where
 		in_slate: VersionedSlate,
 		dest_acct_name: Option<String>,
 		message: Option<String>,
-		addr_from: Option<String>,
 	) -> Result<VersionedSlate, Error> {
 		let version = in_slate.version();
 		let slate_from = Slate::from(in_slate);
@@ -570,7 +568,6 @@ where
 			&slate_from,
 			dest_acct_name.as_ref().map(String::as_str),
 			message,
-			addr_from,
 		)?;
 		Ok(VersionedSlate::into_version(out_slate, version))
 	}

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -270,7 +270,8 @@ pub trait ForeignRpc {
 			]
 		},
 		null,
-		"Thanks, Yeastplume"
+		"Thanks, Yeastplume",
+		"From Address String"
 		]
 	}
 	# "#
@@ -360,6 +361,7 @@ pub trait ForeignRpc {
 		slate: VersionedSlate,
 		dest_acct_name: Option<String>,
 		message: Option<String>,
+		addr_from: Option<String>,
 	) -> Result<VersionedSlate, Error>;
 
 	/**
@@ -559,6 +561,7 @@ where
 		in_slate: VersionedSlate,
 		dest_acct_name: Option<String>,
 		message: Option<String>,
+		addr_from: Option<String>,
 	) -> Result<VersionedSlate, Error> {
 		let version = in_slate.version();
 		let slate_from = Slate::from(in_slate);
@@ -567,6 +570,7 @@ where
 			&slate_from,
 			dest_acct_name.as_ref().map(String::as_str),
 			message,
+			addr_from,
 		)?;
 		Ok(VersionedSlate::into_version(out_slate, version))
 	}

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -733,7 +733,8 @@ pub trait OwnerRpc: Sync + Send {
 					"block_header_version": 6
 				}
 			},
-			0
+			0,
+			""
 		]
 	}
 	# "#
@@ -751,7 +752,12 @@ pub trait OwnerRpc: Sync + Send {
 
 	```
 	 */
-	fn tx_lock_outputs(&self, slate: VersionedSlate, participant_id: usize) -> Result<(), Error>;
+	fn tx_lock_outputs(
+		&self,
+		slate: VersionedSlate,
+		participant_id: usize,
+		addr_to: Option<String>,
+	) -> Result<(), Error>;
 
 	/**
 	Networked version of [Owner::finalize_tx](struct.Owner.html#method.finalize_tx).
@@ -1339,8 +1345,13 @@ where
 		Ok(VersionedSlate::into_version(out_slate, version))
 	}
 
-	fn tx_lock_outputs(&self, slate: VersionedSlate, participant_id: usize) -> Result<(), Error> {
-		Owner::tx_lock_outputs(self, None, &Slate::from(slate), participant_id)
+	fn tx_lock_outputs(
+		&self,
+		slate: VersionedSlate,
+		participant_id: usize,
+		addr_to: Option<String>,
+	) -> Result<(), Error> {
+		Owner::tx_lock_outputs(self, None, &Slate::from(slate), participant_id, addr_to)
 	}
 
 	fn cancel_tx(&self, tx_id: Option<u32>, tx_slate_id: Option<Uuid>) -> Result<(), Error> {
@@ -1551,6 +1562,7 @@ pub fn run_doctest_owner(
 				&slate,
 				None,
 				None,
+				None,
 				true,
 			)
 			.unwrap();
@@ -1558,7 +1570,7 @@ pub fn run_doctest_owner(
 		}
 		// Spit out slate for input to finalize_tx
 		if lock_tx {
-			api_impl::owner::tx_lock_outputs(&mut **w, (&mask2).as_ref(), &slate, 0).unwrap();
+			api_impl::owner::tx_lock_outputs(&mut **w, (&mask2).as_ref(), &slate, 0, None).unwrap();
 		}
 		println!("RECEIPIENT SLATE");
 		println!("{}", serde_json::to_string_pretty(&slate).unwrap());

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -778,7 +778,8 @@ pub trait OwnerRpcS {
 					"block_header_version": 6
 				}
 			},
-			"participant_id": 0
+			"participant_id": 0,
+			"addr_to": "to dest"
 		}
 	}
 	# "#
@@ -801,6 +802,7 @@ pub trait OwnerRpcS {
 		token: Token,
 		slate: VersionedSlate,
 		participant_id: usize,
+		addr_to: Option<String>,
 	) -> Result<(), Error>;
 
 	/**
@@ -2239,12 +2241,14 @@ where
 		token: Token,
 		in_slate: VersionedSlate,
 		participant_id: usize,
+		addr_to: Option<String>,
 	) -> Result<(), Error> {
 		Owner::tx_lock_outputs(
 			self,
 			(&token.keychain_mask).as_ref(),
 			&Slate::from(in_slate),
 			participant_id,
+			addr_to,
 		)
 	}
 

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -379,12 +379,7 @@ where
 						Some(&m) => Some(m.to_owned()),
 					};
 					controller::foreign_single_use(wallet, km, |api| {
-						slate = api.receive_tx(
-							&slate,
-							Some(&args.dest),
-							None,
-							Some("Self".to_string()),
-						)?;
+						slate = api.receive_tx(&slate, Some(&args.dest), None)?;
 						Ok(())
 					})?;
 				}
@@ -467,7 +462,7 @@ where
 			error!("Error validating participant messages: {}", e);
 			return Err(e);
 		}
-		slate = api.receive_tx(&slate, Some(&g_args.account), args.message.clone(), None)?;
+		slate = api.receive_tx(&slate, Some(&g_args.account), args.message.clone())?;
 		Ok(())
 	})?;
 	if method == "emoji" {

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -21,6 +21,7 @@ use crate::libwallet::{
 	address, Error, NodeClient, NodeVersionInfo, Slate, WalletInst, WalletLCProvider,
 	EPIC_BLOCK_HEADER_VERSION,
 };
+
 use crate::util::secp::key::SecretKey;
 use crate::util::{from_hex, static_secp_instance, to_base64, Mutex};
 

--- a/controller/src/display.rs
+++ b/controller/src/display.rs
@@ -152,6 +152,7 @@ pub fn txs(
 		bMG->"Type",
 		bMG->"Shared Transaction Id",
 		bMG->"Creation Time",
+		bMG->"From/To Address",
 		bMG->"TTL Cutoff Height",
 		bMG->"Confirmed?",
 		bMG->"Confirmation Time",
@@ -211,12 +212,19 @@ pub fn txs(
 			Some(_) => "Yes".to_owned(),
 			None => "None".to_owned(),
 		};
+
+		let public_addr = match t.public_addr.clone() {
+			Some(addr) => addr,
+			None => "None".to_owned(),
+		};
+
 		if dark_background_color_scheme {
 			table.add_row(row![
 				bFC->id,
 				bFC->entry_type,
 				bFC->slate_id,
 				bFB->creation_ts,
+				bFB->public_addr,
 				bFB->ttl_cutoff_height,
 				bFC->confirmed,
 				bFB->confirmation_ts,
@@ -237,6 +245,7 @@ pub fn txs(
 					bFb->entry_type,
 					bFD->slate_id,
 					bFB->creation_ts,
+					bFB->public_addr,
 					bFg->confirmed,
 					bFB->confirmation_ts,
 					bFD->num_inputs,
@@ -255,6 +264,7 @@ pub fn txs(
 					bFb->entry_type,
 					bFD->slate_id,
 					bFB->creation_ts,
+					bFB->public_addr,
 					bFR->confirmed,
 					bFB->confirmation_ts,
 					bFD->num_inputs,

--- a/controller/tests/accounts.rs
+++ b/controller/tests/accounts.rs
@@ -196,7 +196,7 @@ fn accounts_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 		};
 		let mut slate = api.init_send_tx(m, args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate)?;
-		api.tx_lock_outputs(m, &slate, 0)?;
+		api.tx_lock_outputs(m, &slate, 0, None)?;
 
 		slate = api.finalize_tx(m, &slate)?;
 

--- a/controller/tests/check.rs
+++ b/controller/tests/check.rs
@@ -189,7 +189,7 @@ fn scan_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 		// output tx file
 		let send_file = format!("{}/part_tx_1.tx", test_dir);
 		PathToSlate(send_file.into()).put_tx(&slate)?;
-		api.tx_lock_outputs(m, &slate, 0)?;
+		api.tx_lock_outputs(m, &slate, 0, None)?;
 		Ok(())
 	})?;
 

--- a/controller/tests/file.rs
+++ b/controller/tests/file.rs
@@ -147,7 +147,7 @@ fn file_exchange_test_impl(test_dir: &'static str) -> Result<(), libwallet::Erro
 
 	// wallet 2 receives file, completes, sends file back
 	wallet::controller::foreign_single_use(wallet2.clone(), mask2_i.clone(), |api| {
-		slate = api.receive_tx(&slate, None, Some(sender2_message.clone()), None)?;
+		slate = api.receive_tx(&slate, None, Some(sender2_message.clone()))?;
 		PathToSlate((&receive_file).into()).put_tx(&slate)?;
 		Ok(())
 	})?;

--- a/controller/tests/file.rs
+++ b/controller/tests/file.rs
@@ -122,7 +122,7 @@ fn file_exchange_test_impl(test_dir: &'static str) -> Result<(), libwallet::Erro
 		let mut slate = api.init_send_tx(m, args)?;
 		// output tx file
 		PathToSlate((&send_file).into()).put_tx(&mut slate)?;
-		api.tx_lock_outputs(m, &slate, 0)?;
+		api.tx_lock_outputs(m, &slate, 0, None)?;
 		Ok(())
 	})?;
 
@@ -147,7 +147,7 @@ fn file_exchange_test_impl(test_dir: &'static str) -> Result<(), libwallet::Erro
 
 	// wallet 2 receives file, completes, sends file back
 	wallet::controller::foreign_single_use(wallet2.clone(), mask2_i.clone(), |api| {
-		slate = api.receive_tx(&slate, None, Some(sender2_message.clone()))?;
+		slate = api.receive_tx(&slate, None, Some(sender2_message.clone()), None)?;
 		PathToSlate((&receive_file).into()).put_tx(&slate)?;
 		Ok(())
 	})?;

--- a/controller/tests/invoice.rs
+++ b/controller/tests/invoice.rs
@@ -117,7 +117,7 @@ fn invoice_tx_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 			..Default::default()
 		};
 		slate = api.process_invoice_tx(m, &slate, args)?;
-		api.tx_lock_outputs(m, &slate, 0)?;
+		api.tx_lock_outputs(m, &slate, 0, None)?;
 		Ok(())
 	})?;
 
@@ -186,7 +186,7 @@ fn invoice_tx_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 			..Default::default()
 		};
 		slate = api.process_invoice_tx(m, &slate, args)?;
-		api.tx_lock_outputs(m, &slate, 0)?;
+		api.tx_lock_outputs(m, &slate, 0, None)?;
 		Ok(())
 	})?;
 

--- a/controller/tests/no_change.rs
+++ b/controller/tests/no_change.rs
@@ -87,7 +87,7 @@ fn no_change_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 		};
 		slate = api.init_send_tx(m, args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate)?;
-		api.tx_lock_outputs(m, &slate, 0)?;
+		api.tx_lock_outputs(m, &slate, 0, None)?;
 		slate = api.finalize_tx(m, &slate)?;
 		api.post_tx(m, &slate.tx, false)?;
 		Ok(())
@@ -126,7 +126,7 @@ fn no_change_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 			..Default::default()
 		};
 		slate = api.process_invoice_tx(m, &slate, args)?;
-		api.tx_lock_outputs(m, &slate, 0)?;
+		api.tx_lock_outputs(m, &slate, 0, None)?;
 		Ok(())
 	})?;
 

--- a/controller/tests/payment_proofs.rs
+++ b/controller/tests/payment_proofs.rs
@@ -111,7 +111,7 @@ fn payment_proofs_test_impl(test_dir: &'static str) -> Result<(), libwallet::Err
 		assert_eq!(0, slate.lock_height);
 
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
-		sender_api.tx_lock_outputs(m, &slate, 0)?;
+		sender_api.tx_lock_outputs(m, &slate, 0, None)?;
 
 		// Ensure what's stored in TX log for payment proof is correct
 		let (_, txs) = sender_api.retrieve_txs(m, true, None, Some(slate.id))?;

--- a/controller/tests/repost.rs
+++ b/controller/tests/repost.rs
@@ -132,7 +132,7 @@ fn file_repost_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error>
 
 	wallet::controller::foreign_single_use(wallet1.clone(), mask1_i.clone(), |api| {
 		slate = PathToSlate((&send_file).into()).get_tx()?;
-		slate = api.receive_tx(&slate, None, None, None)?;
+		slate = api.receive_tx(&slate, None, None)?;
 		PathToSlate((&receive_file).into()).put_tx(&slate)?;
 		Ok(())
 	})?;

--- a/controller/tests/repost.rs
+++ b/controller/tests/repost.rs
@@ -117,7 +117,7 @@ fn file_repost_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error>
 		};
 		let slate = api.init_send_tx(m, args)?;
 		PathToSlate((&send_file).into()).put_tx(&slate)?;
-		api.tx_lock_outputs(m, &slate, 0)?;
+		api.tx_lock_outputs(m, &slate, 0, None)?;
 		Ok(())
 	})?;
 
@@ -132,7 +132,7 @@ fn file_repost_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error>
 
 	wallet::controller::foreign_single_use(wallet1.clone(), mask1_i.clone(), |api| {
 		slate = PathToSlate((&send_file).into()).get_tx()?;
-		slate = api.receive_tx(&slate, None, None)?;
+		slate = api.receive_tx(&slate, None, None, None)?;
 		PathToSlate((&receive_file).into()).put_tx(&slate)?;
 		Ok(())
 	})?;
@@ -210,7 +210,7 @@ fn file_repost_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error>
 		};
 		let slate_i = sender_api.init_send_tx(m, args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
-		sender_api.tx_lock_outputs(m, &slate, 0)?;
+		sender_api.tx_lock_outputs(m, &slate, 0, None)?;
 		slate = sender_api.finalize_tx(m, &mut slate)?;
 		Ok(())
 	})?;

--- a/controller/tests/self_send.rs
+++ b/controller/tests/self_send.rs
@@ -94,7 +94,7 @@ fn self_send_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 		api.tx_lock_outputs(m, &slate, 0, None)?;
 		// Send directly to self
 		wallet::controller::foreign_single_use(wallet1.clone(), mask1_i.clone(), |api| {
-			slate = api.receive_tx(&slate, Some("listener"), None, None)?;
+			slate = api.receive_tx(&slate, Some("listener"), None)?;
 			Ok(())
 		})?;
 		slate = api.finalize_tx(m, &slate)?;

--- a/controller/tests/self_send.rs
+++ b/controller/tests/self_send.rs
@@ -91,10 +91,10 @@ fn self_send_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 			..Default::default()
 		};
 		let mut slate = api.init_send_tx(m, args)?;
-		api.tx_lock_outputs(m, &slate, 0)?;
+		api.tx_lock_outputs(m, &slate, 0, None)?;
 		// Send directly to self
 		wallet::controller::foreign_single_use(wallet1.clone(), mask1_i.clone(), |api| {
-			slate = api.receive_tx(&slate, Some("listener"), None)?;
+			slate = api.receive_tx(&slate, Some("listener"), None, None)?;
 			Ok(())
 		})?;
 		slate = api.finalize_tx(m, &slate)?;

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -115,7 +115,7 @@ fn basic_transaction_api(test_dir: &'static str) -> Result<(), libwallet::Error>
 		assert_eq!(0, slate.lock_height);
 
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
-		sender_api.tx_lock_outputs(m, &slate, 0)?;
+		sender_api.tx_lock_outputs(m, &slate, 0, None)?;
 		slate = sender_api.finalize_tx(m, &slate)?;
 
 		// Check we have a single kernel and that it is a Plain kernel (no lock_height).
@@ -293,7 +293,7 @@ fn basic_transaction_api(test_dir: &'static str) -> Result<(), libwallet::Error>
 		};
 		let slate_i = sender_api.init_send_tx(m, args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
-		sender_api.tx_lock_outputs(m, &slate, 0)?;
+		sender_api.tx_lock_outputs(m, &slate, 0, None)?;
 		slate = sender_api.finalize_tx(m, &slate)?;
 		Ok(())
 	})?;
@@ -402,7 +402,7 @@ fn tx_rollback(test_dir: &'static str) -> Result<(), libwallet::Error> {
 
 		let slate_i = sender_api.init_send_tx(m, args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
-		sender_api.tx_lock_outputs(m, &slate, 0)?;
+		sender_api.tx_lock_outputs(m, &slate, 0, None)?;
 		slate = sender_api.finalize_tx(m, &slate)?;
 		Ok(())
 	})?;

--- a/controller/tests/ttl_cutoff.rs
+++ b/controller/tests/ttl_cutoff.rs
@@ -91,7 +91,7 @@ fn ttl_cutoff_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error> 
 		let slate_i = sender_api.init_send_tx(m, args)?;
 
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
-		sender_api.tx_lock_outputs(m, &slate, 0)?;
+		sender_api.tx_lock_outputs(m, &slate, 0, None)?;
 
 		let (_, txs) = sender_api.retrieve_txs(m, true, None, Some(slate.id))?;
 		let tx = txs[0].clone();
@@ -139,7 +139,7 @@ fn ttl_cutoff_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error> 
 			..Default::default()
 		};
 		let slate_i = sender_api.init_send_tx(m, args)?;
-		sender_api.tx_lock_outputs(m, &slate_i, 0)?;
+		sender_api.tx_lock_outputs(m, &slate_i, 0, None)?;
 		slate = slate_i;
 
 		let (_, txs) = sender_api.retrieve_txs(m, true, None, Some(slate.id))?;

--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -41,6 +41,7 @@ use std::thread::JoinHandle;
 
 use crate::libwallet::api_impl::foreign;
 use crate::libwallet::api_impl::owner;
+
 use epic_wallet_util::epic_core::core::amount_to_hr_string;
 use std::env;
 use std::net::TcpStream;
@@ -494,10 +495,7 @@ where
 					Ok(ret_slate) => {
 						*slate = ret_slate;
 					}
-					Err(e) => {
-						error!("{}", e);
-						()
-					}
+					Err(e) => return Err(Error::EpicboxReceiveTx(format!("{:?}", e)).into()),
 				};
 			}
 

--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -481,7 +481,7 @@ where
 
 	fn process_incoming_slate(
 		&self,
-		_address: Option<String>,
+		address: Option<String>,
 		slate: &mut Slate,
 		_tx_proof: Option<&mut TxProof>,
 	) -> Result<bool, Error> {
@@ -501,6 +501,7 @@ where
 					&slate,
 					None,
 					None,
+					address,
 					false,
 				);
 				*slate = ret_slate.unwrap();

--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -218,23 +218,13 @@ impl EpicboxChannel {
 
 		let container = Container::new(config.clone());
 
-		let (tx, rx): (Sender<bool>, Receiver<bool>) = channel();
+		let (tx, _rx): (Sender<bool>, Receiver<bool>) = channel();
 		let listener = start_epicbox(container.clone(), wallet, keychain_mask, config, tx).unwrap();
 
 		container
 			.lock()
 			.listeners
 			.insert(ListenerInterface::Epicbox, listener);
-		//warn!("Waitng for rx");
-
-		loop {
-			std::thread::sleep(std::time::Duration::from_secs(1));
-			if rx.recv().unwrap() {
-				break;
-			}
-		}
-
-		//warn!("After rx");
 
 		let vslate = VersionedSlate::into_version(slate.clone(), SlateVersion::V2);
 

--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -482,7 +482,7 @@ where
 				// TODO: invoicing
 			} else {
 				info!("Receive new transaction (foreign::receive_tx)");
-				foreign::receive_tx(
+				match foreign::receive_tx(
 					&mut **w,
 					self.keychain_mask.as_ref(),
 					&slate,
@@ -490,7 +490,15 @@ where
 					None,
 					address,
 					false,
-				)?;
+				) {
+					Ok(ret_slate) => {
+						*slate = ret_slate;
+					}
+					Err(e) => {
+						error!("{}", e);
+						()
+					}
+				};
 			}
 
 			Ok(false)

--- a/impls/src/adapters/epicbox.rs
+++ b/impls/src/adapters/epicbox.rs
@@ -481,8 +481,8 @@ where
 			if slate.tx.inputs().len() == 0 {
 				// TODO: invoicing
 			} else {
-				info!("Received new transaction (foreign::receive_tx)");
-				let ret_slate = foreign::receive_tx(
+				info!("Receive new transaction (foreign::receive_tx)");
+				foreign::receive_tx(
 					&mut **w,
 					self.keychain_mask.as_ref(),
 					&slate,
@@ -490,8 +490,7 @@ where
 					None,
 					address,
 					false,
-				);
-				*slate = ret_slate.unwrap();
+				)?;
 			}
 
 			Ok(false)

--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -205,7 +205,7 @@ impl SlateSender for HttpSlateSender {
 						slate_send,
 						null,
 						null
-					]
+			]
 		});
 		trace!("Sending receive_tx request: {}", req);
 

--- a/impls/src/adapters/keybase.rs
+++ b/impls/src/adapters/keybase.rs
@@ -410,6 +410,7 @@ impl SlateReceiver for KeybaseAllChannels {
 								&slate,
 								None,
 								None,
+								Some(channel.clone()),
 								false,
 							);
 							r

--- a/impls/src/epicbox/protocol.rs
+++ b/impls/src/epicbox/protocol.rs
@@ -79,7 +79,11 @@ pub enum ProtocolRequestV2 {
 		ver: String,
 		epicboxmsgid: String,
 	},
-	GetVersion,
+	ClientDetails {
+		wallet_version: String,
+		wallet_mode: String,
+		protocol_version: String,
+	},
 }
 
 impl Display for ProtocolRequest {
@@ -127,7 +131,15 @@ impl Display for ProtocolRequestV2 {
 				signature: _,
 				ver: _,
 			} => write!(f, "{} to {}", "Made for", epicboxmsgid),
-			ProtocolRequestV2::GetVersion {} => write!(f, "{} ", "GetVersion "),
+			ProtocolRequestV2::ClientDetails {
+				ref wallet_version,
+				ref wallet_mode,
+				ref protocol_version,
+			} => write!(
+				f,
+				"Wallet Version {}, Wallet Mode {}, Protocol Version {}",
+				wallet_version, wallet_mode, protocol_version
+			),
 		}
 	}
 }

--- a/impls/src/epicbox/protocol.rs
+++ b/impls/src/epicbox/protocol.rs
@@ -80,7 +80,6 @@ pub enum ProtocolRequestV2 {
 		epicboxmsgid: String,
 	},
 	GetVersion,
-	FastSend,
 }
 
 impl Display for ProtocolRequest {
@@ -129,7 +128,6 @@ impl Display for ProtocolRequestV2 {
 				ver: _,
 			} => write!(f, "{} to {}", "Made for", epicboxmsgid),
 			ProtocolRequestV2::GetVersion {} => write!(f, "{} ", "GetVersion "),
-			ProtocolRequestV2::FastSend {} => write!(f, "{} ", "FastSend "),
 		}
 	}
 }
@@ -175,7 +173,6 @@ pub enum ProtocolResponseV2 {
 	GetVersion {
 		str: String,
 	},
-	FastSend,
 }
 
 impl Display for ProtocolResponse {
@@ -213,7 +210,7 @@ impl Display for ProtocolResponseV2 {
 			ProtocolResponseV2::GetVersion { ref str } => {
 				write!(f, "{} {}", "Version", str)
 			}
-			ProtocolResponseV2::FastSend => write!(f, "{}", "FastSend"),
+
 			ProtocolResponseV2::Slate {
 				ref from,
 				str: _,

--- a/impls/src/error.rs
+++ b/impls/src/error.rs
@@ -18,7 +18,6 @@ use crate::core::libtx;
 use crate::keychain;
 use crate::libwallet;
 use crate::util::secp;
-use epic_wallet_libwallet::Error::LibWallet;
 
 /// Wallet errors, mostly wrappers around underlying crypto or I/O errors.
 #[derive(Clone, thiserror::Error, Eq, PartialEq, Debug)]
@@ -95,6 +94,9 @@ pub enum Error {
 
 	#[error("Epicbox websocket terminated unexpectedly")]
 	EpicboxWebsocketAbnormalTermination,
+
+	#[error("Epicbox ReceiveTx {}", _0)]
+	EpicboxReceiveTx(String),
 }
 
 impl From<libwallet::Error> for Error {
@@ -111,7 +113,7 @@ impl From<sqlite::Error> for Error {
 
 impl From<Error> for epic_wallet_libwallet::Error {
 	fn from(error: Error) -> epic_wallet_libwallet::Error {
-		LibWallet(error.to_string())
+		epic_wallet_libwallet::Error::LibWallet(error.to_string())
 	}
 }
 

--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -391,11 +391,11 @@ impl NodeClient for HTTPNodeClient {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use crate::core::core::{KernelFeatures, OutputFeatures, OutputIdentifier};
-	use crate::core::libtx::build;
-	use crate::core::libtx::ProofBuilder;
-	use crate::keychain::{ExtKeychain, Keychain};
+	//use super::*;
+	//use crate::core::core::{KernelFeatures, OutputFeatures, OutputIdentifier};
+	//use crate::core::libtx::build;
+	//use crate::core::libtx::ProofBuilder;
+	//use crate::keychain::{ExtKeychain, Keychain};
 
 	// JSON api for "push_transaction" between wallet->node currently only supports "feature and commit" inputs.
 	// We will need to revisit this if we decide to support "commit only" inputs (no features) at wallet level.

--- a/impls/src/test_framework/mod.rs
+++ b/impls/src/test_framework/mod.rs
@@ -201,7 +201,6 @@ fn get_pow_type(ftype: &FType, seed: u64) -> pow::Proof {
 		FType::ProgPow => pow::Proof::ProgPowProof {
 			mix: [seed as u8; 32],
 		},
-		
 	}
 }
 
@@ -287,7 +286,7 @@ where
 		};
 		let slate_i = owner::init_send_tx(&mut **w, keychain_mask, args, test_mode)?;
 		let slate = client.send_tx_slate_direct(dest, &slate_i)?;
-		owner::tx_lock_outputs(&mut **w, keychain_mask, &slate, 0)?;
+		owner::tx_lock_outputs(&mut **w, keychain_mask, &slate, 0, Some(dest.to_string()))?;
 		let slate = owner::finalize_tx(&mut **w, keychain_mask, &slate)?;
 		slate
 	};

--- a/impls/src/test_framework/testclient.rs
+++ b/impls/src/test_framework/testclient.rs
@@ -27,9 +27,7 @@ use crate::keychain::Keychain;
 use crate::libwallet;
 use crate::libwallet::api_impl::foreign;
 use crate::libwallet::slate_versions::v3::SlateV3;
-use crate::libwallet::{
-	NodeClient, NodeVersionInfo, Slate,  WalletInst, WalletLCProvider,
-};
+use crate::libwallet::{NodeClient, NodeVersionInfo, Slate, WalletInst, WalletLCProvider};
 use crate::util;
 use crate::util::secp::key::SecretKey;
 use crate::util::secp::pedersen;
@@ -220,6 +218,7 @@ where
 				&mut **w,
 				(&mask).as_ref(),
 				&Slate::from(slate),
+				None,
 				None,
 				None,
 				false,

--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -78,6 +78,7 @@ pub fn receive_tx<'a, T: ?Sized, C, K>(
 	slate: &Slate,
 	dest_acct_name: Option<&str>,
 	message: Option<String>,
+	addr_from: Option<String>,
 	use_test_rng: bool,
 ) -> Result<Slate, Error>
 where
@@ -130,6 +131,7 @@ where
 		use_test_rng,
 	)?;
 	tx::update_message(&mut *w, keychain_mask, &mut ret_slate)?;
+	tx::update_public_addr(&mut *w, keychain_mask, &mut ret_slate, addr_from)?;
 
 	let keychain = w.keychain(keychain_mask)?;
 	let excess = ret_slate.calc_excess(&keychain)?;

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -570,6 +570,7 @@ pub fn tx_lock_outputs<'a, T: ?Sized, C, K>(
 	keychain_mask: Option<&SecretKey>,
 	slate: &Slate,
 	participant_id: usize,
+	addr_to: Option<String>,
 ) -> Result<(), Error>
 where
 	T: WalletBackend<'a, C, K>,
@@ -577,7 +578,7 @@ where
 	K: Keychain + 'a,
 {
 	let context = w.get_private_context(keychain_mask, slate.id.as_bytes(), participant_id)?;
-	selection::lock_tx_context(&mut *w, keychain_mask, slate, &context)
+	selection::lock_tx_context(&mut *w, keychain_mask, slate, &context, addr_to)
 }
 
 /// Finalize slate
@@ -599,6 +600,7 @@ where
 	tx::verify_slate_payment_proof(&mut *w, keychain_mask, &parent_key_id, &context, &sl)?;
 	tx::update_stored_tx(&mut *w, keychain_mask, &context, &mut sl, false)?;
 	tx::update_message(&mut *w, keychain_mask, &mut sl)?;
+
 	{
 		let mut batch = w.batch(keychain_mask)?;
 		batch.delete_private_context(sl.id.as_bytes(), 0)?;

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -280,7 +280,7 @@ pub enum Error {
 	EpicboxReconnectLimit,
 
 	/// LibWallet Error
-	#[error("LibWallet Error: {}", _0)]
+	#[error("LibWallet Error: {:?}", _0)]
 	LibWallet(String),
 
 	#[error("NotFoundErr Error: {}", _0)]

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -105,6 +105,7 @@ pub fn lock_tx_context<'a, T: ?Sized, C, K>(
 	keychain_mask: Option<&SecretKey>,
 	slate: &Slate,
 	context: &Context,
+	addr_to: Option<String>,
 ) -> Result<(), Error>
 where
 	T: WalletBackend<'a, C, K>,
@@ -161,6 +162,7 @@ where
 
 		t.amount_debited = amount_debited;
 		t.messages = messages;
+		t.public_addr = addr_to;
 
 		// store extra payment proof info, if required
 		if let Some(ref p) = slate.payment_proof {

--- a/libwallet/src/tx_proof.rs
+++ b/libwallet/src/tx_proof.rs
@@ -49,7 +49,6 @@ pub enum Error {
 pub struct TxProof {
 	pub address: EpicboxAddress,
 	pub message: String,
-	pub challenge: String,
 	pub signature: Signature,
 	pub key: [u8; 32],
 	pub amount: u64,
@@ -65,7 +64,6 @@ impl TxProof {
 	) -> Result<(EpicboxAddress, VersionedSlate), Error> {
 		let mut challenge = String::new();
 		challenge.push_str(self.message.as_str());
-		challenge.push_str(self.challenge.as_str());
 
 		let public_key = self
 			.address
@@ -91,8 +89,6 @@ impl TxProof {
 
 		let slate: VersionedSlate =
 			serde_json::from_str(&decrypted_message).map_err(|_| Error::ParseSlate)?;
-		//let slate = Slate::deserialize_upgrade(&decrypted_message)
-		//	.map_err(|_| Error::DecryptMessage)?;
 
 		Ok((destination, slate))
 	}
@@ -100,7 +96,6 @@ impl TxProof {
 	pub fn from_response(
 		from: String,
 		message: String,
-		challenge: String,
 		signature: String,
 		secret_key: &SecretKey,
 		expected_destination: Option<&EpicboxAddress>,
@@ -118,7 +113,6 @@ impl TxProof {
 		let proof = TxProof {
 			address,
 			message,
-			challenge,
 			signature,
 			key,
 			amount: 0,

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -819,6 +819,8 @@ pub struct TxLogEntry {
 	/// Additional info needed to stored payment proof
 	#[serde(default)]
 	pub payment_proof: Option<StoredProofInfo>,
+	/// From or To Address tx was send/received
+	pub public_addr: Option<String>,
 }
 
 impl ser::Writeable for TxLogEntry {
@@ -856,6 +858,7 @@ impl TxLogEntry {
 			kernel_excess: None,
 			kernel_lookup_min_height: None,
 			payment_proof: None,
+			public_addr: None,
 		}
 	}
 

--- a/tests/cmd_line_basic.rs
+++ b/tests/cmd_line_basic.rs
@@ -314,7 +314,7 @@ fn command_line_test_impl(test_dir: &str) -> Result<(), epic_wallet_controller::
 	];
 	execute_command(&app, test_dir, "wallet1", &client1, arg_vec.clone()).unwrap();
 
-	let arg_vec = vec![
+	let _arg_vec = vec![
 		"epic-wallet",
 		"-a",
 		"mining",

--- a/tests/owner_v3_lifecycle.rs
+++ b/tests/owner_v3_lifecycle.rs
@@ -406,7 +406,7 @@ fn owner_v3_lifecycle() -> Result<(), epic_wallet_controller::Error> {
 		let res = api.process_invoice_tx(m, &slate, args);
 		assert!(res.is_ok());
 		slate = res.unwrap();
-		api.tx_lock_outputs(m, &slate, 0)?;
+		api.tx_lock_outputs(m, &slate, 0, None)?;
 
 		Ok(())
 	})


### PR DESCRIPTION
The new field From/To Address makes it possible to store the sender/receiver address that was used when creating a new transaction, or receiving a transaction in wallet.
This field is stored outside the slate data and is only available in the wallet db for local usage.

Adds a new optional parameter "addr_to" to api function "tx_lock_outputs".
Adds a new optional parameter "addr_from" to internal function "foreign::receive_tx"