### PR TITLE
Change epicbox default to epicbox.epiccash.com

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -18,7 +18,7 @@ I. 	***WARNINGS***
 
 II. 	###DEPENDENCIES###
 
-	Sync'd EPIC Server Node. Download EPIC server node from https://epic.tech/downloads/ and follow instructions to sync the node before proceeding.
+	Sync'd EPIC Server Node. Download EPIC server node from https://epiccash.com/downloads/ and follow instructions to sync the node before proceeding.
 
 	TOR: Not mandatory but preferrable to avoid port forwarding configuration or ngrok account setup/use. Follow steps below to install TOR
 

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1874,7 +1874,7 @@ pub trait OwnerRpcS {
 		"jsonrpc": "2.0",
 		"result": {
 			"Ok":  {
-				"domain": "epicbox.epic.tech",
+				"domain": "epicbox.epiccash.com",
 				"port": 443,
 				"public_key": "esWVpwMwUyYoxta4EpGPQQEBYdm3wBqCcggVswNyquoLHaLjFdwq"
 			}

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -175,7 +175,7 @@ pub struct EpicboxConfig {
 impl Default for EpicboxConfig {
 	fn default() -> EpicboxConfig {
 		EpicboxConfig {
-			epicbox_domain: Some("epicbox.epic.tech".to_owned()),
+			epicbox_domain: Some("epicbox.epiccash.com".to_owned()),
 			epicbox_port: Some(443),
 			epicbox_protocol_unsecure: Some(false),
 			epicbox_address_index: Some(0),

--- a/libwallet/src/epicbox_address.rs
+++ b/libwallet/src/epicbox_address.rs
@@ -23,7 +23,7 @@ const EPICBOX_ADDRESS_VERSION_MAINNET: [u8; 2] = [1, 0];
 const EPICBOX_ADDRESS_VERSION_TESTNET: [u8; 2] = [1, 136];
 
 const EPICBOX_ADDRESS_REGEX: &str = r"^(epicbox://)?(?P<public_key>[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{52})(@(?P<domain>[a-zA-Z0-9\.]+)(:(?P<port>[0-9]*))?)?$";
-const DEFAULT_EPICBOX_DOMAIN: &str = "epicbox.epic.tech";
+const DEFAULT_EPICBOX_DOMAIN: &str = "epicbox.epiccash.com";
 pub const DEFAULT_EPICBOX_PORT_80: u16 = 80;
 pub const DEFAULT_EPICBOX_PORT_443: u16 = 443;
 


### PR DESCRIPTION
Switches all references from `epic.tech` to new `epiccash.com`, including default epicbox instance.