### PR TITLE
remove libsqlite3-sys package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,6 @@ dependencies = [
  "hyper-rustls 0.24.2",
  "hyper-timeout",
  "lazy_static",
- "libsqlite3-sys",
  "log",
  "parking_lot 0.6.4",
  "rand 0.5.6",
@@ -1264,7 +1263,6 @@ dependencies = [
  "epic_wallet_config",
  "epic_wallet_util",
  "lazy_static",
- "libsqlite3-sys",
  "log",
  "rand 0.5.6",
  "regex",
@@ -2167,17 +2165,6 @@ dependencies = [
  "bitflags 2.4.2",
  "libc",
  "redox_syscall 0.4.1",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9eb7b8e152b6a01be6a4a2917248381875758250dc3df5d46caf9250341dda"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -28,7 +28,6 @@ chrono = { version = "0.4.4", features = ["serde"] }
 bitvec = "1"
 emoji = "0.2.1"
 sqlite = "0.31.1"
-libsqlite3-sys = { version = ">=0.8.0, <0.13.0", optional = true, features = ["bundled"] }
 lazy_static = "1"
 http = "0.2"
 hyper-timeout = "0.4"

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -27,7 +27,6 @@ sha3 = "0.8"
 byteorder = "1"
 data-encoding = "2"
 sqlite = "0.31.1"
-libsqlite3-sys = { version = ">=0.8.0, <0.13.0", optional = true, features = ["bundled"] }
 sha2 = "0.9"
 digest = "0.9"
 ring = "0.16.20"


### PR DESCRIPTION
Closes #114

Remove:
`libsqlite3-sys = { version = ">=0.8.0, <0.13.0", optional = true, features = ["bundled"] }`

from: `impls/Cargo.toml`, `libwallet/Cargo.toml`