### PR TITLE
Remove non-existent cucumber tests in epic-wallet

### DIFF
--- a/.github/workflows/epic-wallet-master-branch.yml
+++ b/.github/workflows/epic-wallet-master-branch.yml
@@ -86,37 +86,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  cucumber-tests:
-    if: github.ref == 'refs/heads/main' || github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Cache Cargo registry
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-
-
-      - name: Cache Cargo build
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-
-
-      - name: Build
-        run: cargo build --workspace --all-targets
-
-      - name: Run cucumber tests
-        run: cargo test --test cucumber --features cucumber-tests -- --nocapture

--- a/.github/workflows/epic-wallet-master-branch.yml
+++ b/.github/workflows/epic-wallet-master-branch.yml
@@ -6,11 +6,12 @@ on:
       - '**'
     tags:
       - 'v*.*.*'
+
   pull_request:
-    branches:
-      - '**'
+    types: [opened, synchronize, reopened]
+
   schedule:
-    - cron: '0 2 * * *' # Every day at 2am UTC
+    - cron: '0 2 * * *'
 
 jobs:
   build-and-test:
@@ -21,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
@@ -30,7 +31,7 @@ jobs:
           override: true
 
       - name: Cache Cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -38,7 +39,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache Cargo build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
@@ -57,7 +58,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
These don't exist for wallet. `cargo test` seems like the only thing to run for wallet.